### PR TITLE
统一资产添加文案，修改添加用户流程，修复添加系统用户使用key推送，不生成密码

### DIFF
--- a/jperm/views.py
+++ b/jperm/views.py
@@ -512,10 +512,10 @@ def perm_role_push(request):
         task = MyTask(push_resource)
         ret = {}
 
-        # 因为要先建立用户，所以password 是必选项，而push key是在 password也完成的情况下的 可选项
+        # 因为要先建立用户，而push key是在 password也完成的情况下的 可选项
         # 1. 以秘钥 方式推送角色
         if key_push:
-            ret["pass_push"] = task.add_user(role.name, CRYPTOR.decrypt(role.password))
+            ret["pass_push"] = task.add_user(role.name)
             ret["key_push"] = task.push_key(role.name, os.path.join(role.key_path, 'id_rsa.pub'))
 
         # 2. 推送账号密码

--- a/juser/user_api.py
+++ b/juser/user_api.py
@@ -183,7 +183,7 @@ def server_del_user(username):
     bash('userdel -r %s' % username)
 
 
-def get_display_msg(user, password, ssh_key_pwd, send_mail_need=False):
+def get_display_msg(user, password='', ssh_key_pwd='', send_mail_need=False):
     if send_mail_need:
         msg = u'添加用户 %s 成功！ 用户密码已发送到 %s 邮箱！' % (user.name, user.email)
     else:

--- a/juser/user_api.py
+++ b/juser/user_api.py
@@ -137,7 +137,7 @@ def gen_ssh_key(username, password='',
 
     if authorized_keys:
         auth_key_dir = os.path.join(home, username, '.ssh')
-        mkdir(auth_key_dir, username=username , mode=0700)
+        mkdir(auth_key_dir, username=username, mode=0700)
         authorized_key_file = os.path.join(auth_key_dir, 'authorized_keys')
         with open(private_key_file+'.pub') as pub_f:
             with open(authorized_key_file, 'w') as auth_f:
@@ -146,15 +146,13 @@ def gen_ssh_key(username, password='',
         chown(authorized_key_file, username)
 
 
-def server_add_user(username, password, ssh_key_pwd='', ssh_key_login_need=True):
+def server_add_user(username, ssh_key_pwd=''):
     """
     add a system user in jumpserver
     在jumpserver服务器上添加一个用户
     """
-    bash("useradd -s '%s' '%s'; echo '%s'; echo '%s:%s' | chpasswd " %
-         (os.path.join(BASE_DIR, 'init.sh'), username, password, username, password))
-    if ssh_key_login_need:
-        gen_ssh_key(username, ssh_key_pwd)
+    bash("useradd -s '%s' '%s'" % (os.path.join(BASE_DIR, 'init.sh'), username))
+    gen_ssh_key(username, ssh_key_pwd)
 
 
 def user_add_mail(user, kwargs):
@@ -171,7 +169,7 @@ def user_add_mail(user, kwargs):
         您的web登录密码： %s
         您的ssh密钥文件密码： %s
         密钥下载地址： %s/juser/key/down/?uuid=%s
-        说明： 请登陆后再下载密钥！
+        说明： 请登陆跳板机后台下载密钥, 然后使用密钥登陆跳板机！
     """ % (user.name, user.username, user_role.get(user.role, u'普通用户'),
            kwargs.get('password'), kwargs.get('ssh_key_pwd'), URL, user.uuid)
     send_mail(mail_title, mail_msg, MAIL_FROM, [user.email], fail_silently=False)
@@ -185,27 +183,17 @@ def server_del_user(username):
     bash('userdel -r %s' % username)
 
 
-def get_display_msg(user, password, ssh_key_pwd, ssh_key_login_need, send_mail_need):
+def get_display_msg(user, password, ssh_key_pwd, send_mail_need=False):
     if send_mail_need:
         msg = u'添加用户 %s 成功！ 用户密码已发送到 %s 邮箱！' % (user.name, user.email)
-        return msg
-
-    if ssh_key_login_need:
-        msg = u"""
-        跳板机地址： %s
-        用户名：%s
-        密码：%s
-        密钥密码：%s
-        密钥下载url: %s/juser/key/down/?uuid=%s
-        该账号密码可以登陆web和跳板机。
-        """ % (URL, user.username, password, ssh_key_pwd, URL, user.uuid)
     else:
         msg = u"""
-        跳板机地址： %s \n
-        用户名：%s \n
-        密码：%s \n
+        跳板机地址： %s <br />
+        用户名：%s <br />
+        密码：%s <br />
+        密钥密码：%s <br />
+        密钥下载url: %s/juser/key/down/?uuid=%s <br />
         该账号密码可以登陆web和跳板机。
-        """ % (URL, user.username, password)
-
+        """ % (URL, user.username, password, ssh_key_pwd, URL, user.uuid)
     return msg
 

--- a/juser/views.py
+++ b/juser/views.py
@@ -153,8 +153,7 @@ def user_add(request):
         ssh_key_pwd = PyCrypt.gen_rand_pass(16)
         extra = request.POST.getlist('extra', [])
         is_active = False if '0' in extra else True
-        ssh_key_login_need = True
-        send_mail_need = True if '2' in extra else False
+        send_mail_need = True if '1' in extra else False
 
         try:
             if '' in [username, password, ssh_key_pwd, name, role]:
@@ -176,7 +175,7 @@ def user_add(request):
                                    ssh_key_pwd=ssh_key_pwd,
                                    is_active=is_active,
                                    date_joined=datetime.datetime.now())
-                server_add_user(username, password, ssh_key_pwd, ssh_key_login_need)
+                server_add_user(username, ssh_key_pwd)
                 user = get_object(User, username=username)
                 if groups:
                     user_groups = []
@@ -193,7 +192,7 @@ def user_add(request):
             else:
                 if MAIL_ENABLE and send_mail_need:
                     user_add_mail(user, kwargs=locals())
-                msg = get_display_msg(user, password, ssh_key_pwd, ssh_key_login_need, send_mail_need)
+                msg = get_display_msg(user, password, ssh_key_pwd, send_mail_need)
     return my_render('juser/user_add.html', locals(), request)
 
 
@@ -361,7 +360,7 @@ def user_edit(request):
         admin_groups = request.POST.getlist('admin_groups', [])
         extra = request.POST.getlist('extra', [])
         is_active = True if '0' in extra else False
-        email_need = True if '2' in extra else False
+        email_need = True if '1' in extra else False
         user_role = {'SU': u'超级管理员', 'GA': u'部门管理员', 'CU': u'普通用户'}
 
         if user_id:

--- a/juser/views.py
+++ b/juser/views.py
@@ -175,7 +175,7 @@ def user_add(request):
                                    ssh_key_pwd=ssh_key_pwd,
                                    is_active=is_active,
                                    date_joined=datetime.datetime.now())
-                server_add_user(username, ssh_key_pwd)
+                server_add_user(username=username, ssh_key_pwd=ssh_key_pwd)
                 user = get_object(User, username=username)
                 if groups:
                     user_groups = []
@@ -192,7 +192,7 @@ def user_add(request):
             else:
                 if MAIL_ENABLE and send_mail_need:
                     user_add_mail(user, kwargs=locals())
-                msg = get_display_msg(user, password, ssh_key_pwd, send_mail_need)
+                msg = get_display_msg(user, password=password, ssh_key_pwd=ssh_key_pwd, send_mail_need=send_mail_need)
     return my_render('juser/user_add.html', locals(), request)
 
 

--- a/templates/jasset/asset_add.html
+++ b/templates/jasset/asset_add.html
@@ -50,24 +50,23 @@
 
                                         <div class="hr-line-dashed"></div>
                                         <div class="form-group">
-                                            <label for="j_group" class="col-sm-2 control-label">管理账号<span class="red-fonts"> *</span></label>
+                                            <label for="j_group" class="col-sm-2 control-label">管理用户<span class="red-fonts"> *</span></label>
                                             <div class="col-sm-2">
                                                 <div class="radio i-checks">
-                                                    <label>
+                                                    <label style="padding-left: 0">
                                                         <input type="checkbox" checked="checked" id="id_use_default_auth" name="use_default_auth"><span> 使用默认 </span>
                                                     </label>
                                                 </div>
                                             </div>
                                         </div>
-                                        <p class="col-sm-offset-2">Tips: 管理账号是服务器存在的root等高权限账号，用来推送新建系统用户</p>
+                                        <p class="col-sm-offset-2">Tips: 管理用户是服务器存在的root或拥有sudo的用户，用来推送系统用户</p>
                                         <div class="form-group" id="admin_account" style="display: none">
-                                            <div class="hr-line-dashed"></div>
-                                            <label class="col-sm-2 control-label"> 管理用户名<span class="red-fonts">*</span> </label>
+                                            <label class="col-sm-2 control-label"> <span class="red-fonts"></span> </label>
                                             <div class="col-sm-3">
                                                 <input type="text" placeholder="Username" name="username" class="form-control">
                                             </div>
 
-                                            <label class="col-sm-1 control-label"> 密码<span class="red-fonts">*</span> </label>
+                                            <label class="col-sm-1 control-label"> <span class="red-fonts"></span> </label>
                                             <div class="col-sm-4">
                                                 <input type="password" placeholder="Password" name="password" class="form-control">
                                             </div>

--- a/templates/jasset/asset_edit.html
+++ b/templates/jasset/asset_edit.html
@@ -57,20 +57,19 @@
                                             <label for="j_group" class="col-sm-2 control-label">管理账号 <span class="red-fonts">*</span></label>
                                             <div class="col-sm-2">
                                                 <div class="radio i-checks">
-                                                    <label>
+                                                    <label style="padding-left: 0">
                                                         <input type="checkbox" {% if asset.use_default_auth %} checked="checked" {% endif %} id="id_use_default_auth" name="use_default_auth"><span> 使用默认 </span>
                                                     </label>
                                                 </div>
                                             </div>
                                         </div>
                                         <div class="form-group" id="admin_account" {% if asset.use_default_auth %} style="display: none" {% endif %}>
-                                            <div class="hr-line-dashed"></div>
-                                            <label class="col-sm-2 control-label"> 管理用户名 <span class="red-fonts">*</span> </label>
+                                            <label class="col-sm-2 control-label"> </label>
                                             <div class="col-sm-3">
                                                 <input type="text" value="{{ asset.username }}" name="username" class="form-control">
                                             </div>
 
-                                            <label class="col-sm-1 control-label"> 密码<span class="red-fonts">*</span> </label>
+                                            <label class="col-sm-1 control-label"> </label>
                                             <div class="col-sm-4">
                                                 <input type="password" value="" name="password" placeholder="不填写即不更改密码." class="form-control">
                                             </div>

--- a/templates/juser/user_add.html
+++ b/templates/juser/user_add.html
@@ -28,7 +28,7 @@
                                 <div class="alert alert-warning text-center">{{ error }}</div>
                             {% endif %}
                             {% if msg %}
-                                <div class="alert alert-success text-center">{{ msg }}</div>
+                                <div class="alert alert-success">{{ msg | safe }}</div>
                             {% endif %}
                             <div class="form-group">
                                 <label for="username" class="col-sm-2 control-label">用户名<span class="red-fonts">*</span></label>
@@ -99,14 +99,9 @@
                                         <label><input type="checkbox" value="0" name="extra" >禁用 </label>
                                     </div>
                                 </div>
-{#                                <div class="col-sm-2">#}
-{#                                    <div class="checkbox i-checks">#}
-{#                                        <label><input type="checkbox" value="1" name="extra">ssh key登录 </label>#}
-{#                                    </div>#}
-{#                                </div>#}
                                 <div class="col-sm-2">
                                     <div class="checkbox i-checks">
-                                        <label><input type="checkbox" value="2" name="extra">发送邮件 </label>
+                                        <label><input type="checkbox" value="1" name="extra" checked>发送邮件 </label>
                                     </div>
                                 </div>
                             </div>

--- a/templates/juser/user_edit.html
+++ b/templates/juser/user_edit.html
@@ -116,7 +116,7 @@
                                 </div>
                                 <div class="col-sm-2">
                                     <div class="checkbox i-checks">
-                                        <label><input type="checkbox" value="2" name="extra">发送邮件 </label>
+                                        <label><input type="checkbox" value="1" name="extra">发送邮件 </label>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
commit f60a8969268ddcab0e029fb9821b990f90113846
Author: ibuler <ibuler@qq.com>
Date:   Wed Feb 24 12:32:41 2016 +0800

    modify(jasset) 统一管理用户文案

    所有用得到管理用户文案的地，都进行了统一
    更改了 管理用户使用默认的对齐
    去掉了分隔线

commit b6fc8b777f20884f12ebe7d5d6714d42ebb88014
Author: ibuler <ibuler@qq.com>
Date:   Wed Feb 24 12:29:47 2016 +0800

    change(juser) 修改用户添加流程

    1. 添加新用户，不在为该用户设置密码
    2. 强制用户使用key登陆跳板机，为了安全性
    3. 更改邮件文案和不发送邮件提示文案

commit caefbdc9175cf21b4f5f803edfba7e2b4dc88fb1
Author: ibuler <ibuler@qq.com>
Date:   Wed Feb 24 11:34:33 2016 +0800

    fix(juser) 推送系统用户，选择密钥时不为用户生成密码

    当推送系统用户时，选择系统用户使用密钥时没有必要为系统用户生成密码，
    以免造成安全上的问题,在代码上也属于冗余.