### PR TITLE
整合Tornado和Django，修复阻断功能

### DIFF
--- a/jumpserver/views.py
+++ b/jumpserver/views.py
@@ -344,7 +344,7 @@ def download(request):
 def exec_cmd(request):
     role = request.GET.get('role')
     check_assets = request.GET.get('check_assets', '')
-    web_terminal_uri = '%s/exec?role=%s' % (WEB_SOCKET_HOST, role)
+    web_terminal_uri = '/ws/exec?role=%s' % (role)
     return my_render('exec_cmd.html', locals(), request)
 
 
@@ -356,7 +356,8 @@ def web_terminal(request):
     if asset:
         print asset
         hostname = asset.hostname
-    web_terminal_uri = '%s/ws/terminal?id=%s&role=%s' % (WEB_SOCKET_HOST, asset_id, role_name)
+    # web_terminal_uri = '%s/ws/terminal?id=%s&role=%s' % (WEB_SOCKET_HOST, asset_id, role_name)
+    web_terminal_uri = '/ws/terminal?id=%s&role=%s' % (asset_id, role_name)
     return render_to_response('jlog/web_terminal.html', locals())
 
 

--- a/jumpserver/views.py
+++ b/jumpserver/views.py
@@ -356,7 +356,7 @@ def web_terminal(request):
     if asset:
         print asset
         hostname = asset.hostname
-    web_terminal_uri = '%s/terminal?id=%s&role=%s' % (WEB_SOCKET_HOST, asset_id, role_name)
+    web_terminal_uri = '%s/ws/terminal?id=%s&role=%s' % (WEB_SOCKET_HOST, asset_id, role_name)
     return render_to_response('jlog/web_terminal.html', locals())
 
 

--- a/run_websocket.py
+++ b/run_websocket.py
@@ -442,7 +442,7 @@ def main():
             (r'/monitor', MonitorHandler),
             (r'/ws/terminal', WebTerminalHandler),
             (r'/kill', WebTerminalKillHandler),
-            (r'/exec', ExecHandler),
+            (r'/ws/exec', ExecHandler),
             (r"/static/(.*)", tornado.web.StaticFileHandler,
              dict(path=os.path.join(os.path.dirname(__file__), "static"))),
             ('.*', tornado.web.FallbackHandler, dict(fallback=container)),

--- a/run_websocket.py
+++ b/run_websocket.py
@@ -315,7 +315,8 @@ class WebTerminalHandler(tornado.websocket.WebSocketHandler):
         logger.debug('Websocket: request web terminal Host: %s User: %s Role: %s' % (asset.hostname, self.user.username,
                                                                                      login_role.name))
         self.term = WebTty(self.user, asset, login_role, login_type='web')
-        self.term.remote_ip = self.request.remote_ip
+        # self.term.remote_ip = self.request.remote_ip
+        self.term.remote_ip = self.request.headers.get("X-Real_IP")
         self.ssh = self.term.get_connection()
         self.channel = self.ssh.invoke_shell(term='xterm')
         WebTerminalHandler.tasks.append(MyThread(target=self.forward_outbound))

--- a/run_websocket.py
+++ b/run_websocket.py
@@ -439,8 +439,8 @@ def main():
     }
     tornado_app = tornado.web.Application(
         [
-            # (r'/monitor', MonitorHandler),
-            (r'/terminal', WebTerminalHandler),
+            (r'/monitor', MonitorHandler),
+            (r'/ws/terminal', WebTerminalHandler),
             (r'/kill', WebTerminalKillHandler),
             (r'/exec', ExecHandler),
             (r"/static/(.*)", tornado.web.StaticFileHandler,

--- a/templates/exec_cmd.html
+++ b/templates/exec_cmd.html
@@ -29,7 +29,7 @@
         protocol = 'wss://';
     }
 
-    var wsUri = protocol + "{{ web_terminal_uri }}"; //请求的websocket url
+    var wsUri = protocol + document.URL.match(RegExp('//(.*?)/'))[1] + "{{ web_terminal_uri }}"; //请求的websocket url
     var ws = new WebSocket(wsUri);
 
     function createSystemMessage(message) {

--- a/templates/jlog/log_online.html
+++ b/templates/jlog/log_online.html
@@ -216,12 +216,14 @@
            var g_url = "{% url 'log_kill' %}?id=" + num;
        }
 
-       $.ajax({
-           type: "GET",
-           url: g_url+"&sessionid={{ session_id }}",
-           success: window.open("{% url 'log_list' 'online' %}", "_self")
-       });
-
+{#       $.ajax({#}
+{#           type: "GET",#}
+{#           url: g_url+"&sessionid={{ session_id }}",#}
+{#           success: window.open("{% url 'log_list' 'online' %}", "_self")#}
+{#       });#}
+       $.get(g_url+"&sessionid={{ session_id }}", function () {
+           window.open("{% url 'log_list' 'online' %}", "_self")
+       })
 }
 </script>
 {% endblock %}

--- a/templates/jlog/log_online.html
+++ b/templates/jlog/log_online.html
@@ -213,7 +213,7 @@
        if (login_type=='web'){
            var g_url = '{{ web_kill_uri }}' + '?id=' + num;
        } else {
-           var g_url = "{% url 'log_kill' %} }?id=" + num;
+           var g_url = "{% url 'log_kill' %} ?id=" + num;
        }
 
        $.ajax({

--- a/templates/jlog/log_online.html
+++ b/templates/jlog/log_online.html
@@ -213,7 +213,7 @@
        if (login_type=='web'){
            var g_url = '{{ web_kill_uri }}' + '?id=' + num;
        } else {
-           var g_url = "{% url 'log_kill' %} ?id=" + num;
+           var g_url = "{% url 'log_kill' %}?id=" + num;
        }
 
        $.ajax({

--- a/templates/jlog/web_terminal.html
+++ b/templates/jlog/web_terminal.html
@@ -48,7 +48,7 @@
                     protocol = 'wss://';
                 }
 
-                var endpoint = protocol + '{{ web_terminal_uri }}';
+                var endpoint = protocol + document.URL.match(RegExp('//(.*?)/'))[1] + '{{ web_terminal_uri }}';
 
                 if (window.WebSocket) {
                     this._connection = new WebSocket(endpoint);


### PR DESCRIPTION
1.修改run_websocket.py 使得其可以包含Django直接运行
其中修改部分URL代码，使得其适合修改后的代码
之后运行仅需要Python run_websocket.py 即可，manage.py 不需要运行了

2.修复log kill（阻断）功能