### PR TITLE
Ip get bug

### DIFF
--- a/run_websocket.py
+++ b/run_websocket.py
@@ -317,6 +317,8 @@ class WebTerminalHandler(tornado.websocket.WebSocketHandler):
         self.term = WebTty(self.user, asset, login_role, login_type='web')
         # self.term.remote_ip = self.request.remote_ip
         self.term.remote_ip = self.request.headers.get("X-Real-IP")
+        if not self.term.remote_ip:
+            self.term.remote_ip = self.request.remote_ip
         self.ssh = self.term.get_connection()
         self.channel = self.ssh.invoke_shell(term='xterm')
         WebTerminalHandler.tasks.append(MyThread(target=self.forward_outbound))

--- a/service.sh
+++ b/service.sh
@@ -30,7 +30,7 @@ start() {
                  echo "jumpserver  is running..."
                  success "$jump_start"
         else
-                 daemon python $base_dir/manage.py runserver 0.0.0.0:80 &>> /tmp/jumpserver.log 2>&1 &
+#                 daemon python $base_dir/manage.py runserver 0.0.0.0:80 &>> /tmp/jumpserver.log 2>&1 &
                  daemon python $base_dir/manage.py crontab add &>> /tmp/jumpserver.log 2>&1
                  daemon python $base_dir/run_websocket.py &> /dev/null 2>&1 &
          sleep 4


### PR DESCRIPTION
用户IP获取修复

如果使用nginx

则会获取self.request.headers.get("X-Real-IP")，self.request.remote_ip的值为127.0.0.1

如果不使用nginx
self.request.headers.get("X-Real-IP")为null，self.request.remote_ip的值为正确的ip地址

注释了django runserver