### PR TITLE
安装脚本默认数据库用户名

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -203,7 +203,7 @@ class PreSetup(object):
             else:
                 db_host = raw_input('请输入数据库服务器IP [127.0.0.1]: ').strip()
                 db_port = raw_input('请输入数据库服务器端口 [3306]: ').strip()
-                db_user = raw_input('请输入数据库服务器用户 [root]: ').strip()
+                db_user = raw_input('请输入数据库服务器用户 [jumpserver]: ').strip()
                 db_pass = raw_input('请输入数据库服务器密码: ').strip()
                 db = raw_input('请输入使用的数据库 [jumpserver]: ').strip()
 


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/1198380/13373116/2f02fafc-dd99-11e5-812f-28f099b7d360.png)

安装脚本的默认用户名设定是jumpserver，此处显示默认为root会导致安装失败

我就一路回车使用root安装，然后发现安装不成功