### PR TITLE
fix(userdel) 修复无法删除在线用户bug

### DIFF
--- a/juser/user_api.py
+++ b/juser/user_api.py
@@ -180,7 +180,7 @@ def server_del_user(username):
     delete a user from jumpserver linux system
     删除系统上的某用户
     """
-    bash('userdel -r %s' % username)
+    bash('userdel -r -f %s' % username)
 
 
 def get_display_msg(user, password='', ssh_key_pwd='', send_mail_need=False):


### PR DESCRIPTION
当用户已经登录到jumpserver时，web上删除用户时失败，也没有提示

修改方法: userdel -r -f 强制删除

close #156