### PR TITLE
fix(web terminal) Windows 浏览器使用chrome -换行

### DIFF
--- a/templates/jlog/web_terminal.html
+++ b/templates/jlog/web_terminal.html
@@ -11,7 +11,7 @@
 
             .terminal {
                 border: #000 solid 5px;
-                font-family: "Monaco", "DejaVu Sans Mono", "Liberation Mono", monospace;
+                font-family: "Monaco", "Microsoft Yahei", "DejaVu Sans Mono", "Liberation Mono", monospace;
                 font-size: 11px;
                 color: #f0f0f0;
                 background: #000;


### PR DESCRIPTION
经测试由于字体原因，可以安装Monaco字体解决，然而不太方便

添加第二字体为 微软雅黑，经测试解决

fixed
close #158