### PR TITLE
fix (jperm):   修复密码添加和更新 role时 密码过长引起的bug

### DIFF
--- a/jperm/models.py
+++ b/jperm/models.py
@@ -26,7 +26,7 @@ class PermSudo(models.Model):
 class PermRole(models.Model):
     name = models.CharField(max_length=100, unique=True)
     comment = models.CharField(max_length=100, null=True, blank=True, default='')
-    password = models.CharField(max_length=128)
+    password = models.CharField(max_length=512)
     key_path = models.CharField(max_length=100)
     date_added = models.DateTimeField(auto_now=True)
     sudo = models.ManyToManyField(PermSudo, related_name='perm_role')

--- a/jperm/views.py
+++ b/jperm/views.py
@@ -290,6 +290,8 @@ def perm_role_add(request):
             if name == "root":
                 raise ServerError(u'禁止使用root用户作为系统用户，这样非常危险！')
             default = get_object(Setting, name='default')
+            if len(password) > 64:
+                raise ServerError(u'密码长度不能超过64位!')
 
             if password:
                 encrypt_pass = CRYPTOR.encrypt(password)
@@ -446,6 +448,8 @@ def perm_role_edit(request):
         role_sudo_names = request.POST.getlist("sudo_name")
         role_sudos = [PermSudo.objects.get(id=sudo_id) for sudo_id in role_sudo_names]
         key_content = request.POST.get("role_key", "")
+        if len(role_password) > 64:
+            raise ServerError(u'密码长度不能超过64位!')
 
         try:
             if not role:


### PR DESCRIPTION
1. 修改password字段的长度，对称加密过后的字符串会变长，所有设置得比较大(512)
2. 修改后端检查密码长度，并触发异常。