### PR TITLE
修复主机组编辑时回车导致主机丢失问题

### DIFF
--- a/templates/jasset/group_edit.html
+++ b/templates/jasset/group_edit.html
@@ -57,7 +57,7 @@
                     {% if smg %}
                         <div class="alert alert-success text-center">{{ smg }}</div>
                     {% endif %}
-                    <form id="assetForm" method="post" class="form-horizontal">
+                    <form id="assetForm" method="post" class="form-horizontal" onkeydown="if(event.keyCode==13){return false;}">
                         <div class="form-group"><label class="col-sm-2 control-label"> 主机组名<span class="red-fonts">*</span></label>
                             <div class="col-sm-8" name="group_id" value="{{ group.id }}"><input type="text" value="{{ group.name }}" placeholder="Name" name="name" class="form-control"></div>
                         </div>


### PR DESCRIPTION
在主机组编辑页面，如果直接执行回车会导致主机组中主机信息丢失。
本修复方法是关闭回车提交