### PR TITLE
使示例可以正确运行

### DIFF
--- a/jperm/ansible_api.py
+++ b/jperm/ansible_api.py
@@ -493,8 +493,8 @@ if __name__ == "__main__":
                  # # "ansible_become_user": "root",
                  # "ansible_become_pass": "yusky0902",
                  }]
-    cmd = Command(resource)
-    print cmd.run('ls')
+    cmd.run('ls',pattern='*')
+    print cmd.results_raw
 
     # resource = [{"hostname": "192.168.10.148", "port": "22", "username": "root", "password": "xxx"}]
     # task = Tasks(resource)


### PR DESCRIPTION
为了安全pattern=空，后示例代码无法使用，运行示例时加上pattern='*'，使示例可以返回正确的结果