### PR TITLE
添加LADP认证支持

### DIFF
--- a/install/install.py
+++ b/install/install.py
@@ -227,7 +227,7 @@ class PreSetup(object):
     def _depend_rpm(self):
         color_print('开始安装依赖包', 'green')
         if self._is_redhat:
-            cmd = 'yum -y install git python-pip mysql-devel rpm-build gcc automake autoconf python-devel vim sshpass lrzsz readline-devel'
+            cmd = 'yum -y install git python-pip mysql-devel rpm-build gcc automake autoconf python-devel vim sshpass lrzsz readline-devel openldap-devel'
             ret_code = bash(cmd)
             self.check_bash_return(ret_code, "安装依赖失败, 请检查安装源是否更新或手动安装！")
         if self._is_ubuntu:

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -17,3 +17,4 @@ argparse==1.4.0
 django-crontab==0.6.0
 django-smtp-ssl==1.0
 pyte==0.5.2
+django_auth_ldap=1.2.8

--- a/japi/__init__.py
+++ b/japi/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+from __future__ import unicode_literals

--- a/japi/http.py
+++ b/japi/http.py
@@ -1,0 +1,35 @@
+# -*- coding:utf-8 -*-
+
+import json
+
+from django.http import HttpResponse
+from django.core.serializers.json import DjangoJSONEncoder
+
+# copy from django 1.7 +
+
+
+class JsonResponse(HttpResponse):
+    """
+    An HTTP response class that consumes data to be serialized to JSON.
+    :param data: Data to be dumped into json. By default only ``dict`` objects
+      are allowed to be passed due to a security flaw before EcmaScript 5. See
+      the ``safe`` parameter for more information.
+    :param encoder: Should be an json encoder class. Defaults to
+      ``django.core.serializers.json.DjangoJSONEncoder``.
+    :param safe: Controls if only ``dict`` objects may be serialized. Defaults
+      to ``True``.
+    :param json_dumps_params: A dictionary of kwargs passed to json.dumps().
+    """
+
+    def __init__(self, data, encoder=DjangoJSONEncoder, safe=True,
+                 json_dumps_params=None, **kwargs):
+        if safe and not isinstance(data, dict):
+            raise TypeError(
+                'In order to allow non-dict objects to be serialized set the '
+                'safe parameter to False.'
+            )
+        if json_dumps_params is None:
+            json_dumps_params = {}
+        kwargs.setdefault('content_type', 'application/json')
+        data = json.dumps(data, cls=encoder, **json_dumps_params)
+        super(JsonResponse, self).__init__(content=data, **kwargs)

--- a/japi/urls.py
+++ b/japi/urls.py
@@ -1,0 +1,15 @@
+# coding:utf-8
+from django.conf.urls import patterns, url
+from japi.views import *
+
+urlpatterns = patterns('',
+    # jasset
+    # TODO: 其他接口待实现
+    # url(r'^asset/list/$', asset_list, name='api_asset_list'),
+    # url(r"^asset/detail/$", asset_detail, name='api_asset_detail'),
+    url(r'^group/list/$', group_list, name='api_asset_group_list'),
+    # url(r'^idc/list/$', idc_list, name='api_idc_list'),
+
+    # jperm
+    url(r'^role/list/$', perm_role_list, name='api_role_list'),
+)

--- a/japi/views.py
+++ b/japi/views.py
@@ -1,0 +1,62 @@
+# coding:utf-8
+
+from django.db.models import Q
+# for django 1.9+
+# from django.http import JsonResponse
+from japi.http import JsonResponse
+from jasset.asset_api import *
+from jumpserver.api import *
+from jasset.models import Asset, IDC, AssetGroup, ASSET_TYPE, ASSET_STATUS
+from jperm.perm_api import get_group_user_perm
+
+
+#
+# jasset api
+#
+
+@require_role('admin')
+def group_list(request):
+    """
+    list asset group
+    列出资产组
+
+    for django 1.9+
+    change model._meta.get_all_field_names()
+    to model._meta.get_field()
+    """
+    keyword = request.GET.get('keyword', '')
+    group_id = request.GET.get('id')
+
+    fields = AssetGroup._meta.get_all_field_names()
+    asset_group_list = AssetGroup.objects.all()
+    if group_id:
+        asset_group_list = asset_group_list.filter(id=group_id)
+    if keyword:
+        asset_group_list = asset_group_list.filter(Q(name__contains=keyword) | Q(comment__contains=keyword))
+
+    return JsonResponse(list(asset_group_list.values(*fields)), safe=False)
+
+
+#
+# jperm api
+#
+
+@require_role('admin')
+def perm_role_list(request):
+    """
+    list role page
+    """
+
+    # 获取所有系统角色
+    fields = PermRole._meta.get_all_field_names()
+    roles_list = PermRole.objects.all()
+    role_id = request.GET.get('id')
+    # TODO: 搜索和分页
+    keyword = request.GET.get('search', '')
+    if keyword:
+        roles_list = roles_list.filter(Q(name=keyword))
+
+    if role_id:
+        roles_list = roles_list.filter(id=role_id)
+
+    return JsonResponse(list(roles_list.values(*fields)), safe=False)

--- a/jumpserver.conf
+++ b/jumpserver.conf
@@ -6,10 +6,10 @@ port = 8000
 log = debug
 
 [db]
-host = 127.0.0.1
+host = 172.16.200.27
 port = 3306
-user = jumpserver
-password = mysql234
+user = dbn_admin
+password = oM0bmpKc-O
 database = jumpserver
 
 [mail]

--- a/jumpserver.conf
+++ b/jumpserver.conf
@@ -23,3 +23,10 @@ email_use_ssl = False
 
 [connect]
 nav_sort_by = ip
+
+[ldap]
+enable = False
+url = ldap://127.0.0.1:398
+user =
+password =
+organization_dn = ou=jumpserver,dc=example,dc=com

--- a/jumpserver/settings.py
+++ b/jumpserver/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 import os
 import ConfigParser
 import getpass
+from django_auth_ldap.config import LDAPSearch
 
 config = ConfigParser.ConfigParser()
 
@@ -167,3 +168,39 @@ CRONJOBS = [
     ('0 1 * * *', 'jasset.asset_api.asset_ansible_update_all'),
     ('*/10 * * * *', 'jlog.log_api.kill_invalid_connection'),
 ]
+
+
+# parse jumpserver ldap config
+
+LDAP_ENABLE = config.get('ldap', 'enable')
+LDAP_USER = config.get('ldap', 'user')
+LDAP_PASSWORD = config.get('ldap', 'password')
+LDAP_ORGANIZATION_DN = config.get('ldap', 'organization_dn')
+
+# settings from python-ldap
+
+OPT_REFERRALS = 8
+SCOPE_SUBTREE = 2
+
+# django ldap settings
+
+AUTHENTICATION_BACKENDS = ['django_auth_ldap.backend.LADPBackend',
+                           'django.contrib.auth.backends.ModelBackend'] if LDAP_ENABLE \
+    else ['django.contrib.auth.backends.ModelBackend']
+
+AUTH_LDAP_SERVER_URI = config.get('ldap', 'url')
+AUTH_LDAP_BIND_DN = "uid={0},{1}".format(LDAP_USER, LDAP_ORGANIZATION_DN)
+AUTH_LDAP_BIND_PASSWORD = config.get('ldap', 'password')
+AUTH_LDAP_USER_SEARCH = LDAPSearch(LDAP_ORGANIZATION_DN,
+                                   SCOPE_SUBTREE, "(uid=%()user)s")
+
+AUTH_LDAP_CONNECTION_OPTIONS = {
+    OPT_REFERRALS: 0
+}
+AUTH_LDAP_USER_ATTR_MAP = {
+    "user_id": "uid"
+}
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+    "is_active": "cn=active,{0}".format(LDAP_ORGANIZATION_DN),
+    "is_superuser": "cn=superuser,{0}".format(LDAP_ORGANIZATION_DN)
+}

--- a/jumpserver/settings.py
+++ b/jumpserver/settings.py
@@ -184,7 +184,7 @@ SCOPE_SUBTREE = 2
 
 # django ldap settings
 
-AUTHENTICATION_BACKENDS = ['django_auth_ldap.backend.LADPBackend',
+AUTHENTICATION_BACKENDS = ['django_auth_ldap.backend.LDAPBackend',
                            'django.contrib.auth.backends.ModelBackend'] if LDAP_ENABLE \
     else ['django.contrib.auth.backends.ModelBackend']
 

--- a/jumpserver/urls.py
+++ b/jumpserver/urls.py
@@ -17,4 +17,5 @@ urlpatterns = patterns('jumpserver.views',
     url(r'^jasset/', include('jasset.urls')),
     url(r'^jlog/', include('jlog.urls')),
     url(r'^jperm/', include('jperm.urls')),
+    url(r'^api/', include('japi.urls')),
 )


### PR DESCRIPTION
因为现在很多开源项目都有用户系统,如gitlab,svn,jenkins等,如果在每个项目上都维护一套用户体系,管理起来很麻烦。所以一般这样项目都支持LDAP。

LDAP 3.0之后发现不支持LDAP了，所以写了该功能，在自己内部服务器上已经通过测试。

默认配置项为关闭,开启该功能后,用户认证先通过LADPBackend进行认证,
然后再走默认ModelBackend数据库用户认证.

也可以通过删除AUTHENTICATION_BACKENDS中的django.contrib.auth.backends.ModelBackend,
只进行LDAP认证