### PR TITLE
Replace os.makedirs to mkdir.

### DIFF
--- a/jlog/views.py
+++ b/jlog/views.py
@@ -274,7 +274,7 @@ class TermLogRecorder(object):
         self.filename = filename
         filepath = os.path.join(path, 'tty', date, filename + '.zip')
         if not os.path.isdir(os.path.join(path, 'tty', date)):
-            os.makedirs(os.path.join(path, 'tty', date), mode=0777)
+            mkdir(os.path.join(path, 'tty', date), mode=777)
         while os.path.isfile(filepath):
             filename = str(uuid.uuid4())
             filepath = os.path.join(path, 'tty', date, filename + '.zip')


### PR DESCRIPTION
## 解决Tty Logs 日志跨天后目录权限不对的问题
- `os.makedirs(name, mode=0o777, exist_ok=False)`  该方法在某些系统中传入的权限参数`mode`不生效 ;