### PR TITLE
修复通过重置密码链接重置密码的一个小Bug

### DIFF
--- a/juser/views.py
+++ b/juser/views.py
@@ -328,7 +328,7 @@ def reset_password(request):
         else:
             user = get_object(User, uuid=uuid_r)
             if user:
-                user.password = PyCrypt.md5_crypt(password)
+                user.set_password(password)
                 user.save()
                 return http_success(request, u'密码重设成功')
             else:


### PR DESCRIPTION
存储在数据库的用户信息是使用Django框架的库提供的默认Hash算法pbkdf2_sha256，在登录后修改用户信息时使用的是Django的用户接口set_password(juser/views.py的change_info方法），但是在重置密码的reset_password方法中却使用了纯MD5（PyCrypt.md5_crypt）加密。
这个应该是一个Bug，但是不影响使用，查了下Django的django/contrib/auth/hashers.py中的identify_hasher方法，支持纯MD5和SHA1的（根据Hash结果串长度），所以修改了密码登录也是没有问题的。