### PR TITLE
fix 点击取消不能回退到用户列表页面

### DIFF
--- a/templates/juser/user_edit.html
+++ b/templates/juser/user_edit.html
@@ -123,7 +123,7 @@
                             <div class="hr-line-dashed"></div>
                             <div class="form-group">
                                 <div class="col-sm-4 col-sm-offset-2">
-                                    <button class="btn btn-white" type="submit">取消</button>
+                                    <a class="btn btn-white" href="/juser/user/list/">取消</a>
                                     <button id="submit_button" class="btn btn-primary" type="submit">确认保存</button>
                                 </div>
                             </div>


### PR DESCRIPTION
现在无论是点击`取消`还是`确认保存`都是把用户页面的数据 post  提交到后台