### PR TITLE
修复sudo别名取消后不回收bug

### DIFF
--- a/jperm/ansible_api.py
+++ b/jperm/ansible_api.py
@@ -409,6 +409,17 @@ class MyTask(MyRunner):
         self.run("script", module_args1, become=True)
         return self.results
 
+    def recyle_cmd_alias(self, role_name):
+        """
+        recyle sudo cmd alias
+        :return:
+        """
+        if role_name == 'root':
+            return {"status": "failed", "msg": "can't recyle root privileges"}
+        module_args = "sed -i 's/^%s.*//' /etc/sudoers" % role_name
+        self.run("command", module_args, become=True)
+        return self.results
+
 
 class CustomAggregateStats(callbacks.AggregateStats):
     """                                                                             

--- a/jperm/views.py
+++ b/jperm/views.py
@@ -533,6 +533,8 @@ def perm_role_push(request):
             sudo_list = set([sudo for sudo in role.sudo.all()])  # set(sudo1, sudo2, sudo3)
             if sudo_list:
                 ret['sudo'] = task.push_sudo_file([role], sudo_list)
+            else:
+                ret['sudo'] = task.recyle_cmd_alias(role.name)
 
         logger.debug('推送role结果: %s' % ret)
         success_asset = {}


### PR DESCRIPTION
当用户没有的role 已经没没有关联sudo 别名时，会删除该用户。