### PR TITLE
使用json.dumps 格式化输出

### DIFF
--- a/jperm/ansible_api.py
+++ b/jperm/ansible_api.py
@@ -3,7 +3,7 @@
 
 from tempfile import NamedTemporaryFile
 import os.path
-
+import json
 from ansible.inventory.group import Group
 from ansible.inventory.host import Host
 from ansible.inventory import Inventory
@@ -143,9 +143,9 @@ class MyRunner(MyInventory):
                      become_pass=become_pass,
                      transport=transport
                      )
-        self.results_raw = hoc.run()
-        logger.debug(self.results_raw)
-        return self.results_raw
+        res = json.dumps(hoc.run(), indent=4)
+        logger.debug(res)
+        return res
 
     @property
     def results(self):
@@ -200,7 +200,7 @@ class Command(MyInventory):
                      pattern=pattern,
                      forks=forks,
                      )
-        self.results_raw = hoc.run()
+        json.dumps(hoc.run(), indent=4)
 
     @property
     def result(self):


### PR DESCRIPTION
使用json.dumps(hoc.run(), indent=4) 替换 hoc.run() = self.results_raw
同样达到包json 转换为 字典，并使输出格式化 好看

{
    'dark': {},
    'contacted': {
        '127.0.0.1': {
            u'cmd': [
                u'ls'
            ],
            u'end': u'2016-12-1115: 27: 0 1.732819',
            u'stdout': u'SpringBlog\nansible\nansible_api.py\neventlet\ngevent\ngs-handling-form-submission\npycharm\npypy\ntest\ntest_java.java\nthreading_bak.py',
            u'changed': True,
            u'start': u'2016-12-1115: 27: 0 1.730680',
            u'delta': u'0: 0 0: 0 0.002139',
            u'stderr': u'',
            u'rc': 0,
            'invocation': {
                'module_name': 'command',
                'module_complex_args': {},
                'module_args': u'ls'
            },
            u'warnings': []
        }
    }
}