### PR TITLE
change sign_t return from bytes to str.

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -68,7 +68,7 @@ class Signer(object):
 
     def sign_t(self, value, expires_in=3600):
         s = TimedJSONWebSignatureSerializer(self.secret_key, expires_in=expires_in)
-        return s.dumps(value)
+        return str(s.dumps(value), encoding="utf8")
 
     def unsign_t(self, value):
         s = TimedJSONWebSignatureSerializer(self.secret_key)


### PR DESCRIPTION
在用户修改密码的邮件中的链接，如：http://10.99.1.4:8080/users/password/reset?token=b'eyJhb ... ... xNpQ' ， token=b'xxxx'，在解析时会当成一个整体的字符串处理而不是一个 bytes。
>>> token = b'xxxxx'
>>> url_token = '%s' % token
>>> url_token
"b'xxxxx'"

在 unsign_t 函数中处理时会传入一个类似 "b'xxxxx'" 的错误参数。