### PR TITLE
fix bug: variable i should be the host name

### DIFF
--- a/apps/assets/tasks.py
+++ b/apps/assets/tasks.py
@@ -72,7 +72,7 @@ def test_admin_user_connective_period():
     for i in summary['success']:
         cache.set(i, '1', 2*60*60*60)
 
-    for i in summary['failed']:
+    for i, msg in summary['failed']:
         cache.set(i, '0', 60*60*60)
     return summary
 


### PR DESCRIPTION
fix bug: variable i is not the host name, because summary['failed'] is something like [("hostname1", "error message 1"),("hostname1", "error message 1")]