### PR TITLE
token过期bug

### DIFF
--- a/apps/users/utils.py
+++ b/apps/users/utils.py
@@ -154,7 +154,7 @@ def check_user_valid(**kwargs):
     return None, _('Password or SSH public key invalid')
 
 
-def refresh_token(token, user, expiration=3600):
+def refresh_token(token, user, expiration=settings.CONFIG.TOKEN_EXPIRATION or 3600):
     cache.set(token, user.id, expiration)
 
 


### PR DESCRIPTION
目前的逻辑是用户每一次登陆coco都会更新token, 更新的函数过期时间是一个不可更改的值3600, 如果用户自定义的过期时间大于这个值的话, 就会出现{token: userid}这个cache早于{userid_remote_ip: token}这个cache过期, 导致用户可以获取token, 但是服务端根据token获取不到用户ID,就会出现报错Invalid token or cache refreshed, 生产环境遇到的问题.