### PR TITLE
bugfix: 解决用户失效时间为空时，无法使用密码进行ssh登录跳板机的问题

### DIFF
--- a/apps/users/models/user.py
+++ b/apps/users/models/user.py
@@ -204,7 +204,7 @@ class User(AbstractUser):
             'wechat': self.wechat,
             'phone': self.phone,
             'comment': self.comment,
-            'date_expired': self.date_expired.strftime('%Y-%m-%d %H:%M:%S')
+            'date_expired': self.date_expired.strftime('%Y-%m-%d %H:%M:%S') if self.date_expired is not None else None
         })
 
     @classmethod

--- a/apps/users/templates/users/user_profile.html
+++ b/apps/users/templates/users/user_profile.html
@@ -22,7 +22,7 @@
                         </ul>
                     </div>
                     <div class="tab-content">
-                        <div class="col-sm-7">
+                        <div class="col-sm-7" style="padding-left: 0;">
                             <div class="ibox float-e-margins">
                                 <div class="ibox-title">
                                     <span class="label label-primary"><b>{{ user.name }}</b></span>


### PR DESCRIPTION
- bugfix: 解决用户失效时间为空时，无法使用密码进行ssh登录跳板机的问题。
- bugfix: 个人信息页面个人信息pannel错位。

```
AttributeError at /api/users/v1/auth/
'NoneType' object has no attribute 'strftime'

Request Method: POST
Request URL: http://127.0.0.1:8080/api/users/v1/auth/
Django Version: 1.11.4
Python Executable: /opt/py3/bin/python
Python Version: 3.6.1
Python Path: ['/data/deployment/jumpserver/apps', '/usr/local/lib/python36.zip', '/usr/local/lib/python3.6', '/usr/local/lib/python3.6/lib-dynload', '/opt/py3/lib/python3.6/site-packages', '/data/deployment/jumpserver', '/data/deployment/jumpserver/apps']
Server time: Wed, 30 Aug 2017 23:18:47 +0800
Installed Applications:
['users.apps.UsersConfig',
 'assets.apps.AssetsConfig',
 'perms.apps.PermsConfig',
 'ops.apps.OpsConfig',
 'audits.apps.AuditsConfig',
 'common.apps.CommonConfig',
 'applications.apps.ApplicationsConfig',
 'rest_framework',
 'rest_framework_swagger',
 'django_filters',
 'bootstrap3',
 'captcha',
 'django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.messages',
 'django.contrib.staticfiles']
Installed Middleware:
['django.middleware.security.SecurityMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.locale.LocaleMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'jumpserver.middleware.TimezoneMiddleware',
 'jumpserver.middleware.DemoMiddleware']


Traceback:  

File "/opt/py3/lib/python3.6/site-packages/django/core/handlers/exception.py" in inner
  41.             response = get_response(request)
File "/opt/py3/lib/python3.6/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)
File "/opt/py3/lib/python3.6/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/usr/local/lib/python3.6/contextlib.py" in inner
  53.                 return func(*args, **kwds)
File "/opt/py3/lib/python3.6/site-packages/django/views/decorators/csrf.py" in wrapped_view
  58.         return view_func(*args, **kwargs)
File "/opt/py3/lib/python3.6/site-packages/django/views/generic/base.py" in view
  68.             return self.dispatch(request, *args, **kwargs)
File "/opt/py3/lib/python3.6/site-packages/rest_framework/views.py" in dispatch
  489.             response = self.handle_exception(exc)
File "/opt/py3/lib/python3.6/site-packages/rest_framework/views.py" in handle_exception
  449.             self.raise_uncaught_exception(exc)
File "/opt/py3/lib/python3.6/site-packages/rest_framework/views.py" in dispatch
  486.             response = handler(request, *args, **kwargs)
File "/data/deployment/jumpserver/apps/users/api.py" in post
  166.             return Response({'token': token, 'user': user.to_json()})
File "/data/deployment/jumpserver/apps/users/models/user.py" in to_json
  207.             'date_expired': self.date_expired.strftime('%Y-%m-%d %H:%M:%S')

Exception Type: AttributeError at /api/users/v1/auth/
Exception Value: 'NoneType' object has no attribute 'strftime'
Request information:
USER: AnonymousUser
GET: No GET data
POST: No POST data
FILES: No FILES data
COOKIES: No cookie data
```