### PR TITLE
[Bugfix] ops Add app_name

### DIFF
--- a/apps/ops/urls/api_urls.py
+++ b/apps/ops/urls/api_urls.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from rest_framework.routers import DefaultRouter
 from .. import api
 
+app_name = 'ops'
 
 router = DefaultRouter()
 router.register(r'v1/tasks', api.TaskViewSet, 'task')

--- a/apps/ops/urls/view_urls.py
+++ b/apps/ops/urls/view_urls.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 from django.conf.urls import url
 from .. import views
 
+app_name = 'ops'
+
 __all__ = ["urlpatterns"]
 
 urlpatterns = [


### PR DESCRIPTION
ops模块缺少app_name，导致后面无法执行makemigrations