### PR TITLE
修复资产树节点过滤bug

### DIFF
--- a/apps/assets/models/node.py
+++ b/apps/assets/models/node.py
@@ -38,7 +38,7 @@ class Node(models.Model):
         mark = self.child_mark
         self.child_mark += 1
         self.save()
-        return "{}:{}".format(self.key, mark)
+        return "{}:[{}]".format(self.key, mark)
 
     def create_child(self, value):
         child_key = self.get_next_child_key()
@@ -46,7 +46,7 @@ class Node(models.Model):
         return child
 
     def get_children(self):
-        return self.__class__.objects.filter(key__regex=r'{}:[0-9]+$'.format(self.key))
+        return self.__class__.objects.filter(key__regex=r'{}:[\[\]0-9]+$'.format(self.key))
 
     def get_all_children(self):
         return self.__class__.objects.filter(key__startswith='{}:'.format(self.key))
@@ -77,13 +77,13 @@ class Node(models.Model):
         return self.get_all_assets().filter(is_active=True)
 
     def is_root(self):
-        return self.key == '0'
+        return self.key == '[0]'
 
     @property
     def parent(self):
-        if self.key == "0":
+        if self.key == "[0]":
             return self.__class__.root()
-        elif not self.key.startswith("0"):
+        elif not self.key.startswith("[0]"):
             return self.__class__.root()
 
         parent_key = ":".join(self.key.split(":")[:-1])
@@ -114,6 +114,7 @@ class Node(models.Model):
     @classmethod
     def root(cls):
         obj, created = cls.objects.get_or_create(
-            key='0', defaults={"key": '0', 'value': "ROOT"}
+            key='[0]', defaults={"key": '[0]', 'value': "ROOT"}
         )
         return obj
+


### PR DESCRIPTION
修改原 assets_node key 字段的存储方式：
原数据存储方式

```
0
0:1:1
0:1:11
0:1:111
```
现数据存储方式
```
[0]
[0]:[1]:[1]
[0]:[1]:[11]
[0]:[1]:[111]
```

在使用 

```
queryset = queryset.filter(nodes__key__startswith=node.key).distinct()
```

能正确区别
```
[0]:[1]:[1]
```
和 
```
[0]:[1]:[11]
```
```
[0]:[1]:[111]
```

等
