### PR TITLE
修复：资产树节点，取消model value unique，并添加唯一性校验，serializers/api中；修改新增节点计数器规则；

### DIFF
--- a/apps/assets/api/node.py
+++ b/apps/assets/api/node.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from rest_framework import generics, mixins
+from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework_bulk import BulkModelViewSet
@@ -110,7 +111,9 @@ class NodeChildrenApi(mixins.ListModelMixin, generics.CreateAPIView):
         value = request.data.get("value")
         values = [child.value for child in instance.get_children()]
         if value in values:
-            raise AssertionError('The same level node name cannot be the same')
+            raise ValidationError(
+                'The same level node name cannot be the same'
+            )
         node = instance.create_child(value=value)
         return Response(
             {"id": node.id, "key": node.key, "value": node.value},

--- a/apps/assets/models/node.py
+++ b/apps/assets/models/node.py
@@ -12,7 +12,10 @@ __all__ = ['Node']
 class Node(models.Model):
     id = models.UUIDField(default=uuid.uuid4, primary_key=True)
     key = models.CharField(unique=True, max_length=64, verbose_name=_("Key"))  # '1:1:1:1'
-    value = models.CharField(max_length=128, unique=True, verbose_name=_("Value"))
+    # value = models.CharField(
+    #     max_length=128, unique=True, verbose_name=_("Value")
+    # )
+    value = models.CharField(max_length=128, verbose_name=_("Value"))
     child_mark = models.IntegerField(default=0)
     date_create = models.DateTimeField(auto_now_add=True)
 
@@ -48,7 +51,7 @@ class Node(models.Model):
         return child
 
     def get_children(self):
-        return self.__class__.objects.filter(key__regex=r'{}:[0-9]+$'.format(self.key))
+        return self.__class__.objects.filter(key__regex=r'^{}:[0-9]+$'.format(self.key))
 
     def get_all_children(self):
         return self.__class__.objects.filter(key__startswith='{}:'.format(self.key))

--- a/apps/assets/serializers/node.py
+++ b/apps/assets/serializers/node.py
@@ -51,6 +51,15 @@ class NodeSerializer(serializers.ModelSerializer):
         fields = ['id', 'key', 'value', 'parent', 'assets_amount', 'is_node']
         list_serializer_class = BulkListSerializer
 
+    def update(self, instance, validated_data):
+        value = validated_data.get('value')
+        if not instance.is_root():
+            children = instance.parent.get_children().exclude(key=instance.key)
+            values = [child.value for child in children]
+            if value in values:
+                raise AssertionError('The same level node name cannot be the same')
+        return super().update(instance, validated_data)
+
     @staticmethod
     def get_parent(obj):
         return obj.parent.id

--- a/apps/assets/serializers/node.py
+++ b/apps/assets/serializers/node.py
@@ -51,14 +51,17 @@ class NodeSerializer(serializers.ModelSerializer):
         fields = ['id', 'key', 'value', 'parent', 'assets_amount', 'is_node']
         list_serializer_class = BulkListSerializer
 
-    def update(self, instance, validated_data):
-        value = validated_data.get('value')
+    def validate(self, data):
+        value = data.get('value')
+        instance = self.instance
         if not instance.is_root():
             children = instance.parent.get_children().exclude(key=instance.key)
             values = [child.value for child in children]
             if value in values:
-                raise AssertionError('The same level node name cannot be the same')
-        return super().update(instance, validated_data)
+                raise serializers.ValidationError(
+                    'The same level node name cannot be the same'
+                )
+        return data
 
     @staticmethod
     def get_parent(obj):

--- a/apps/assets/templates/assets/_asset_list_modal.html
+++ b/apps/assets/templates/assets/_asset_list_modal.html
@@ -98,7 +98,10 @@ function initTree2() {
     $.get("{% url 'api-assets:node-list' %}", function(data, status){
         $.each(data, function (index, value) {
             value["pId"] = value["parent"];
-            value["open"] = true;
+            {#value["open"] = true;#}
+            if (value["key"] === "0") {
+                value["open"] = true;
+            }
             value["name"] = value["value"] + ' (' + value['assets_amount'] + ')';
             value['value'] = value['value'];
         });

--- a/apps/assets/templates/assets/asset_detail.html
+++ b/apps/assets/templates/assets/asset_detail.html
@@ -190,7 +190,7 @@
                                                 <td colspan="2" class="no-borders">
                                                     <select data-placeholder="{% trans 'Nodes' %}" id="groups_selected" class="select2 groups" style="width: 100%" multiple="" tabindex="4">
                                                         {% for node in nodes_remain %}
-                                                        <option value="{{ node.id }}" id="opt_{{ node.id }}" >{{ node.name }}</option>
+                                                        <option value="{{ node.id }}" id="opt_{{ node.id }}" >{{ node }}</option>
                                                         {% endfor %}
                                                     </select>
                                                 </td>
@@ -204,7 +204,7 @@
 
                                         {% for node in asset.nodes.all %}
                                         <tr>
-                                          <td ><b class="bdg_node" data-gid={{ node.id }}>{{ node.name }}</b></td>
+                                          <td ><b class="bdg_node" data-gid={{ node.id }}>{{ node }}</b></td>
                                           <td>
                                               <button class="btn btn-danger pull-right btn-xs btn-leave-node" type="button"><i class="fa fa-minus"></i></button>
                                           </td>

--- a/apps/assets/templates/assets/asset_list.html
+++ b/apps/assets/templates/assets/asset_list.html
@@ -211,6 +211,8 @@ function addTreeNode() {
             };
             newNode.checked = zTree.getSelectedNodes()[0].checked;
             zTree.addNodes(parentNode, 0, newNode);
+            var node = zTree.getNodeByParam('id', newNode.id, parentNode)
+            zTree.editName(node);
         } else {
             alert("{% trans 'Create node failed' %}")
         }
@@ -241,9 +243,9 @@ function removeTreeNode() {
 
 function editTreeNode() {
     hideRMenu();
-	var current_node = zTree.getSelectedNodes()[0];
-	if (!current_node){
-	    return
+    var current_node = zTree.getSelectedNodes()[0];
+    if (!current_node){
+        return
     }
     if (current_node.value) {
         current_node.name = current_node.value;
@@ -398,9 +400,9 @@ function initTree() {
     $.get("{% url 'api-assets:node-list' %}", query_params, function(data, status){
         $.each(data, function (index, value) {
             value["pId"] = value["parent"];
-            {#if (value["key"] === "0") {#}
-            value["open"] = true;
-            {# }#}
+            if (value["key"] === "0") {
+                value["open"] = true;
+             }
             value["name"] = value["value"] + ' (' + value['assets_amount'] + ')';
             value['value'] = value['value'];
         });

--- a/apps/users/templates/users/user_granted_asset.html
+++ b/apps/users/templates/users/user_granted_asset.html
@@ -68,7 +68,7 @@ var asset_table;
 
 function initTable() {
     if (inited){
-        return
+        return asset_table
     } else {
         inited = true;
     }


### PR DESCRIPTION
修复：资产树节点，
1. 取消model value unique，并添加唯一性校验，serializers/api中；
2. 修改新增节点计数器规则；
3. 修改资产树节点默认只展开root节点的直接子节点；
4. 修复从root节点移除资产：如果一个资产既属于root又属于其他节点，那么可以从root节点移除；