### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -33,7 +33,7 @@ enum-compat==0.0.2
 ephem==3.7.6.0
 eventlet==0.22.1
 ForgeryPy==0.1
-greenlet==0.4.12
+greenlet==0.4.13
 gunicorn==19.7.1
 idna==2.6
 itsdangerous==0.24

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -40,7 +40,7 @@ itsdangerous==0.24
 itypes==1.1.0
 Jinja2==2.10
 jmespath==0.9.3
-kombu==4.0.2
+kombu==4.2.0
 ldap3==2.4
 MarkupSafe==1.0
 mysqlclient==1.3.12


### PR DESCRIPTION
greenlet 0.4.12版本在centos 7.4下编译失败，修改为0.4.13后编译通过