### PR TITLE
Update admin_system_settings.rst

### DIFF
--- a/docs/admin_system_settings.rst
+++ b/docs/admin_system_settings.rst
@@ -38,8 +38,8 @@
 ::
 
    # 注意下面的 testuser对应的是你ldap server上存在的用户，填写到配置中需要改为 %(user)s
-   ldapsearch -x -W -h ldap://127.0.0.1:389 -b "ou=People,dc=xxx,dc=com" -D "cn=admin,dc=xxx,dc=com" "(cn=testuser)"
-   ldapsearch -x -W -h ldap://127.0.0.1:389 -b "dc=xxx,dc=com" -D "cn=admin,dc=xxx,dc=com" "(&(cn=testuser)(objectClass=account))"
+   ldapsearch -x -W -H ldap://127.0.0.1:389 -b "ou=People,dc=xxx,dc=com" -D "cn=admin,dc=xxx,dc=com" "(cn=testuser)"
+   ldapsearch -x -W -H ldap://127.0.0.1:389 -b "dc=xxx,dc=com" -D "cn=admin,dc=xxx,dc=com" "(&(cn=testuser)(objectClass=account))"
 
    # extended LDIF
    #


### PR DESCRIPTION
ldapsearch 使用示例的参数错了 使用h 参数会报错 改为 H 正常返回信息
ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)