### PR TITLE
remove useless image

### DIFF
--- a/apps/templates/_footer.html
+++ b/apps/templates/_footer.html
@@ -1,7 +1,7 @@
 <div class="footer fixed">
     <div class="pull-right">
         Version <strong>1.3.1-{% include '_build.html' %}</strong> GPLv2.
-        <img style="display: none" src="http://www.jumpserver.org/img/evaluate_avatar1.jpg">
+        <!--<img style="display: none" src="http://www.jumpserver.org/img/evaluate_avatar1.jpg">-->
     </div>
     <div>
         <strong>Copyright</strong> 北京堆栈科技有限公司 &copy; 2014-2018


### PR DESCRIPTION
引用写死了http协议, https的情况下会触发Mix Content的warning导致浏览器不信任.

此图片页面未发现有实际展示, 建议删除.