### PR TITLE
[Update]删除示例配置中未使用的BROKER_URL配置

### DIFF
--- a/config_example.py
+++ b/config_example.py
@@ -51,11 +51,6 @@ class Config:
     REDIS_HOST = '127.0.0.1'
     REDIS_PORT = 6379
     REDIS_PASSWORD = ''
-    BROKER_URL = 'redis://%(password)s%(host)s:%(port)s/3' % {
-        'password': REDIS_PASSWORD,
-        'host': REDIS_HOST,
-        'port': REDIS_PORT,
-    }
 
     def __init__(self):
         pass


### PR DESCRIPTION
#1404  这位老兄指出了   BROKER_URL 未使用
搜索了 celery 库文件和jumpserver项目 确实只用了CELERY_BROKER_URL, 顺手提一个PR 