### PR TITLE
修改资产过多无法授权的问题

### DIFF
--- a/apps/perms/templates/perms/asset_permission_list.html
+++ b/apps/perms/templates/perms/asset_permission_list.html
@@ -42,7 +42,7 @@
            </div>
           <div class="mail-box-header">
               <div class="uc pull-left m-r-5">
-                   <a class="btn btn-sm btn-primary btn-create-permission">
+                   <a href="/asset-permission/create" class="btn btn-sm btn-primary btn-create-permission">
                        {% trans "Create permission" %}
                    </a>
               </div>


### PR DESCRIPTION
当资产过多，授权按钮需要等ajax获取完资产列表才会绑定事件
导致点击按钮失效，添加多一行属性可以直接填入href进行跳转