### PR TITLE
python-gssapi libkrb5-dev for gssapi/gssapi.h

### DIFF
--- a/requirements/deb_requirements.txt
+++ b/requirements/deb_requirements.txt
@@ -1,1 +1,1 @@
-libtiff5-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk python-dev openssl libssl-dev libldap2-dev libsasl2-dev sqlite gcc automake 
+libtiff5-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk python-dev openssl libssl-dev libldap2-dev libsasl2-dev sqlite gcc automake libkrb5-dev


### PR DESCRIPTION
python-gssapi native build depends gssapi header file from libkrb5-dev