### PR TITLE
#1466 修复测试网关连接性BUG

### DIFF
--- a/apps/assets/utils.py
+++ b/apps/assets/utils.py
@@ -56,7 +56,8 @@ def test_gateway_connectability(gateway):
     try:
         proxy.connect(gateway.ip, username=gateway.username,
                       password=gateway.password,
-                      pkey=gateway.private_key_obj)
+                      pkey=gateway.private_key_obj,
+                      port=gateway.port)
     except(paramiko.AuthenticationException,
            paramiko.BadAuthenticationType,
            SSHException) as e:


### PR DESCRIPTION
测试网关连接性需要设置端口参数，否则会使用默认22端口