### PR TITLE
授权页面分页问题

### DIFF
--- a/apps/perms/api.py
+++ b/apps/perms/api.py
@@ -5,6 +5,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework.views import APIView, Response
 from rest_framework.generics import ListAPIView, get_object_or_404, RetrieveUpdateAPIView
 from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
 
 from common.utils import set_or_append_attr_bulk, get_object_or_none
 from users.permissions import IsValidUser, IsSuperUser, IsSuperUserOrAppUser
@@ -22,6 +23,7 @@ class AssetPermissionViewSet(viewsets.ModelViewSet):
     queryset = AssetPermission.objects.all()
     serializer_class = serializers.AssetPermissionCreateUpdateSerializer
     permission_classes = (IsSuperUser,)
+	pagination_class = LimitOffsetPagination
 
     def get_serializer_class(self):
         if self.action in ("list", 'retrieve'):

--- a/apps/perms/api.py
+++ b/apps/perms/api.py
@@ -25,7 +25,7 @@ class AssetPermissionViewSet(viewsets.ModelViewSet):
     queryset = AssetPermission.objects.all()
     serializer_class = serializers.AssetPermissionCreateUpdateSerializer
     permission_classes = (IsSuperUser,)
-	pagination_class = LimitOffsetPagination
+    pagination_class = LimitOffsetPagination
 
     def get_serializer_class(self):
         if self.action in ("list", 'retrieve'):

--- a/apps/perms/api.py
+++ b/apps/perms/api.py
@@ -5,7 +5,6 @@ from django.shortcuts import get_object_or_404
 from rest_framework.views import APIView, Response
 from rest_framework.generics import ListAPIView, get_object_or_404, RetrieveUpdateAPIView
 from rest_framework import viewsets
-from rest_framework.pagination import LimitOffsetPagination
 
 from common.utils import set_or_append_attr_bulk, get_object_or_none
 from users.permissions import IsValidUser, IsSuperUser, IsSuperUserOrAppUser
@@ -23,7 +22,6 @@ class AssetPermissionViewSet(viewsets.ModelViewSet):
     queryset = AssetPermission.objects.all()
     serializer_class = serializers.AssetPermissionCreateUpdateSerializer
     permission_classes = (IsSuperUser,)
-	pagination_class = LimitOffsetPagination
 
     def get_serializer_class(self):
         if self.action in ("list", 'retrieve'):

--- a/apps/perms/api.py
+++ b/apps/perms/api.py
@@ -5,6 +5,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework.views import APIView, Response
 from rest_framework.generics import ListAPIView, get_object_or_404, RetrieveUpdateAPIView
 from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
 
 from common.utils import set_or_append_attr_bulk, get_object_or_none
 from users.permissions import IsValidUser, IsSuperUser, IsSuperUserOrAppUser
@@ -19,9 +20,12 @@ class AssetPermissionViewSet(viewsets.ModelViewSet):
     """
     资产授权列表的增删改查api
     """
+    filter_fields = ("name",)
+    search_fields = filter_fields
     queryset = AssetPermission.objects.all()
     serializer_class = serializers.AssetPermissionCreateUpdateSerializer
     permission_classes = (IsSuperUser,)
+	pagination_class = LimitOffsetPagination
 
     def get_serializer_class(self):
         if self.action in ("list", 'retrieve'):

--- a/apps/perms/templates/perms/asset_permission_list.html
+++ b/apps/perms/templates/perms/asset_permission_list.html
@@ -208,7 +208,7 @@ function initTable() {
         select: {},
         op_html: $('#actions').html()
     };
-    table = jumpserver.initServerSideDataTable(options);
+    table = jumpserver.initDataTable(options);
     return table
 }
 

--- a/apps/perms/templates/perms/asset_permission_list.html
+++ b/apps/perms/templates/perms/asset_permission_list.html
@@ -208,7 +208,7 @@ function initTable() {
         select: {},
         op_html: $('#actions').html()
     };
-    table = jumpserver.initDataTable(options);
+    table = jumpserver.initServerSideDataTable(options);
     return table
 }
 


### PR DESCRIPTION
修复了授权页面列表过多导致卡死的情况
增加的搜索授权名字的功能 