### PR TITLE
修复LDAP登录第二次会报错的问题

### DIFF
--- a/apps/users/signals_handler.py
+++ b/apps/users/signals_handler.py
@@ -9,6 +9,8 @@ from common.utils import get_logger
 from .signals import post_user_create
 # from .models import User
 
+from django.db import IntegrityError
+from django.db import transaction
 logger = get_logger(__file__)
 
 
@@ -35,5 +37,8 @@ def on_user_create(sender, user=None, **kwargs):
 def on_ldap_create_user(sender, user, ldap_user, **kwargs):
     if user:
         user.source = user.SOURCE_LDAP
-        user.save()
-
+        try:
+            with transaction.atomic():
+                user.save()
+        except IntegrityError:
+            pass


### PR DESCRIPTION
在LDAP用户第二次登录且LDAP属性没有变化的情况下，user.save()在写入数据库的时候会变成insert，这时由于username、email都是主键唯一会导致报错。捕获异常后解决此问题。