### PR TITLE
[Bugfix] operation on closed file.

### DIFF
--- a/apps/ops/celery/logger.py
+++ b/apps/ops/celery/logger.py
@@ -143,7 +143,7 @@ class CeleryTaskFileHandler(CeleryTaskLoggerHandler):
 
     def emit(self, record):
         msg = self.format(record)
-        if not self.f:
+        if not self.f or self.f.closed:
             return
         self.f.write(msg)
         self.f.write(self.terminator)


### PR DESCRIPTION
debug模式有概率出现task日志打印完毕, 但是celery debug日志继续写入导致报错
ValueError : I/O operation on closed file.
