### PR TITLE
[Bugfix] periodic task register null

### DIFF
--- a/apps/ops/celery/signal_handler.py
+++ b/apps/ops/celery/signal_handler.py
@@ -27,7 +27,7 @@ def on_app_ready(sender=None, headers=None, **kwargs):
     logger.debug("Work ready signal recv")
     logger.debug("Start need start task: [{}]".format(", ".join(tasks)))
     for task in tasks:
-        subtask(task).delay()
+        subtask(task)()
 
 
 @worker_shutdown.connect

--- a/apps/ops/celery/signal_handler.py
+++ b/apps/ops/celery/signal_handler.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.core.cache import cache
-from celery import subtask
+from celery import signature
 from celery.signals import (
     worker_ready, worker_shutdown, after_setup_logger
 )
@@ -27,7 +27,7 @@ def on_app_ready(sender=None, headers=None, **kwargs):
     logger.debug("Work ready signal recv")
     logger.debug("Start need start task: [{}]".format(", ".join(tasks)))
     for task in tasks:
-        subtask(task)()
+        signature(task)()
 
 
 @worker_shutdown.connect


### PR DESCRIPTION
在分布式部署情况下, 会出现注册异常,  交由worker执行会无法正确获取_need_registered_period_tasks等list的值, 直接在当前进程执行比较好