### PR TITLE
[Bugfix] node get_all_children

### DIFF
--- a/apps/assets/models/node.py
+++ b/apps/assets/models/node.py
@@ -147,7 +147,7 @@ class Node(OrgModelMixin):
         )
 
     def get_all_children(self, with_self=False):
-        pattern = r'^{0}$|^{0}:' if with_self else r'^{0}'
+        pattern = r'^{0}$|^{0}:' if with_self else r'^{0}:'
         return self.__class__.objects.filter(
             key__regex=pattern.format(self.key)
         )


### PR DESCRIPTION
bugfix: node get_all_children逻辑
bug示例：
当前节点key为`0:1`,存在节点`key`为'0:10','0:11',...时，get_all_children也会将其匹配到
