### PR TITLE
add gcc libc-dev linux-headers make autoconf

### DIFF
--- a/requirements/alpine_requirements.txt
+++ b/requirements/alpine_requirements.txt
@@ -1,1 +1,1 @@
-tiff-dev jpeg-dev zlib-dev freetype-dev lcms-dev libwebp-dev tcl-dev tk-dev python3-dev libressl-dev openldap-dev cyrus-sasl-dev krb5-dev sshpass postgresql-dev mariadb-dev sqlite-dev libffi-dev openssh-client
+tiff-dev jpeg-dev zlib-dev freetype-dev lcms-dev libwebp-dev tcl-dev tk-dev python3-dev libressl-dev openldap-dev cyrus-sasl-dev krb5-dev sshpass postgresql-dev mariadb-dev sqlite-dev libffi-dev openssh-client gcc libc-dev linux-headers make autoconf


### PR DESCRIPTION
add gcc libc-dev linux-headers make autoconf for pip install -r requirements