### PR TITLE
[Bugfix] LDAP同步用户列表中如果API获取到的用户名中有空格，在设置为id的时候默认会取第一个空格前的字符串作为用户名，导致不…

### DIFF
--- a/apps/settings/templates/settings/_ldap_list_users_modal.html
+++ b/apps/settings/templates/settings/_ldap_list_users_modal.html
@@ -58,6 +58,9 @@ function initLdapUsersTable() {
         ele: $('#ldap_list_users_table'),
         ajax_url: '{% url "api-settings:ldap-user-list" %}',
         columnDefs: [
+            {targets: 0, createdCell: function (td, cellData, rowData) {
+                $(td).html("<input type='checkbox' class='text-center ipt_check' id='ID_USERNAME'>".replace("ID_USERNAME", cellData))
+            }},
             {targets: 4, createdCell: function (td, cellData, rowData) {
                 if(cellData){
                     $(td).html('<i class="fa fa-check text-navy"></i>')


### PR DESCRIPTION
…会导入用户