### PR TITLE
Assure group when push system user to asset

### DIFF
--- a/apps/assets/tasks.py
+++ b/apps/assets/tasks.py
@@ -385,6 +385,15 @@ def get_push_linux_system_user_tasks(system_user):
             }
         },
         {
+            'name': 'Add group {}'.format(system_user.username),
+            'action': {
+                'module': 'group',
+                'args': 'name={} state=present'.format(
+                    system_user.username,
+                ),
+            }
+        },
+        {
             'name': 'Check home dir exists',
             'action': {
                 'module': 'stat',


### PR DESCRIPTION
Some OS like SUSE12SP3 may not create group when create an OS user. In this case, the task "Set home dir permission" will always fail as the group doesn't exist in the system.
