### PR TITLE
[Update] 添加wheel依赖

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -53,6 +53,7 @@ pycparser==2.19
 pycrypto==2.6.1
 pyotp==2.2.6
 PyNaCl==1.2.1
+wheel==0.33.6
 python-dateutil==2.6.1
 python-gssapi==0.6.4
 pytz==2018.3


### PR DESCRIPTION
如果未添加wheel依赖，在centos7.7安装python-gssapi==0.6.4时可能报错

#3461 