### PR TITLE
[Update]使用OpenID提供的UserInfo.name作为用户姓名

### DIFF
--- a/apps/authentication/backends/openid/models.py
+++ b/apps/authentication/backends/openid/models.py
@@ -160,7 +160,8 @@ class Client(object):
                 defaults={
                     'email': userinfo.get('email', ''),
                     'first_name': userinfo.get('given_name', ''),
-                    'last_name': userinfo.get('family_name', '')
+                    'last_name': userinfo.get('family_name', ''),
+                    'name': userinfo.get('name', '')
                 }
             )
             oidt_profile = OpenIDTokenProfile(


### PR DESCRIPTION
Signed-off-by: YanzheL <lee.yanzhe@yanzhe.org>

## 解决的问题
当使用OpenID认证时，用户登录后的姓名`User.name`不会被自动设置，并且[会使用用户名作为默认的用户姓名](https://github.com/jumpserver/jumpserver/blob/master/apps/users/models/user.py#L536-L537)，这是一种不合适的做法，因为通常来说`name`和`username`的值是不同的。

## 解决方法
因为OpenID的`UserInfo`会提供来自单点认证系统提供的用户姓名，所以应该把用户登录后的`name`设置为OpenID提供的`name`，这样前端界面就会显示正确用户姓名