### PR TITLE
Update config_example.yml

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -1,11 +1,11 @@
 # SECURITY WARNING: keep the secret key used in production secret!
 # 加密秘钥 生产环境中请修改为随机字符串，请勿外泄, 可使用命令生成 
 # $ cat /dev/urandom | tr -dc A-Za-z0-9 | head -c 49;echo
-SECRET_KEY:
+SECRET_KEY: 
 
 # SECURITY WARNING: keep the bootstrap token used in production secret!
 # 预共享Token coco和guacamole用来注册服务账号，不在使用原来的注册接受机制
-BOOTSTRAP_TOKEN:
+BOOTSTRAP_TOKEN: 
 
 # Development env open this, when error occur display the full process track, Production disable it
 # DEBUG 模式 开启DEBUG后遇到错误时可以看到更多日志


### PR DESCRIPTION
SECRET_KEY 和 BOOTSTRAP_TOKEN 后面默认留个空格，遇到好几个新手对yaml格式不注意了，虽然是个小问题……