### PR TITLE
Update rpm_requirements.txt

### DIFF
--- a/requirements/rpm_requirements.txt
+++ b/requirements/rpm_requirements.txt
@@ -1,1 +1,1 @@
-gcc krb5-devel libtiff-devel libjpeg-devel libzip-devel freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel sshpass openldap-devel mariadb-devel mysql-devel mysql libffi-devel openssh-clients telnet openldap-clients 
+gcc krb5-devel libtiff-devel libjpeg-devel libzip-devel freetype-devel lcms2-devel libwebp-devel tcl-devel tk-devel sshpass openldap-devel libffi-devel openssh-clients telnet openldap-clients 


### PR DESCRIPTION
根据文档中的步骤，MySQL、Nginx、Redis等软件安装是独立在jumpserver部署外的，特别是个性化安装的情况下（比如直接解压二进制包的方式安装MySQL），再在部署jumpserver时使用yum安装会导致冲突和混乱，这里不应再去安装，所以去掉了MySQL相关的包