### PR TITLE
fix：通过 api 添加资产，不写 protocols 时，默认值应该是列表

### DIFF
--- a/apps/assets/serializers/asset.py
+++ b/apps/assets/serializers/asset.py
@@ -65,7 +65,7 @@ class AssetSerializer(BulkOrgResourceModelSerializer):
     platform = serializers.SlugRelatedField(
         slug_field='name', queryset=Platform.objects.all(), label=_("Platform")
     )
-    protocols = ProtocolsField(label=_('Protocols'), required=False)
+    protocols = ProtocolsField(label=_('Protocols'), required=False, default=['ssh/22'])
     domain_display = serializers.ReadOnlyField(source='domain.name', label=_('Domain name'))
     admin_user_display = serializers.ReadOnlyField(source='admin_user.name', label=_('Admin user name'))
     nodes_display = serializers.ListField(child=serializers.CharField(), label=_('Nodes name'), required=False)


### PR DESCRIPTION
复现：
`curl --request POST --url http://192.168.25.117:8080/api/v1/assets/assets/ --header 'Authorization: Bearer ioU8ikrPbH9EEH5TDYYx3UIlTmn0iYvqS2Nw' --header 'Content-Type: application/json' --data '{ "hostname": "test", "ip": "192.168.0.111", "admin_user": "024fcdcc-c18d-48ea-aeef-827f06e593ff", "admin_user_display": "root", "platform": "Linux", "nodes": [ "32d3d9eb-4b88-4e00-9cd1-31a222003844" ] }'`
页面显示为
协议组: s,s,h,/,2,2


@BaiJiangJie 
问题的描述：
在 apps/assets/models/asset.py 文件中：
后台Asset Model的protocols字段保存的类型和格式是: str('ssh/22 rdp/3389')，
所以默认的default=ssh/22是没问题的。

修改的建议：
在 apps/assets/serializers/asset.py 文件中：
查找 protocols = ProtocolsField(label=('Protocols'), required=False)
修改为 protocols = ProtocolsField(label=('Protocols'), required=False, default=['ssh/22'])
来解决。

dup: https://github.com/jumpserver/jumpserver/pull/6051
