### PR TITLE
fix: 因为admin_user表中有历史数据，导致组织无法删除

### DIFF
--- a/apps/orgs/api.py
+++ b/apps/orgs/api.py
@@ -19,7 +19,7 @@ from .serializers import (
 )
 from users.models import User, UserGroup
 from assets.models import (
-    Asset, Domain, AdminUser, SystemUser, Label, Node, Gateway,
+    Asset, Domain, SystemUser, Label, Node, Gateway,
     CommandFilter, CommandFilterRule, GatheredUser
 )
 from applications.models import Application
@@ -35,7 +35,7 @@ logger = get_logger(__file__)
 
 # 部分 org 相关的 model，需要清空这些数据之后才能删除该组织
 org_related_models = [
-    User, UserGroup, Asset, Label, Domain, Gateway, Node, AdminUser, SystemUser, Label,
+    User, UserGroup, Asset, Label, Domain, Gateway, Node, SystemUser, Label,
     CommandFilter, CommandFilterRule, GatheredUser,
     AssetPermission, ApplicationPermission,
     Application,


### PR DESCRIPTION
版本升级后，admin_user表中有历史数据，导致组织页面上无关联关系后，依旧无法删除的问题