### PR TITLE
fix: 修复部署JumpServer在没有密码的redis上时，站内信数量不更新问题

### DIFF
--- a/apps/jumpserver/settings/libs.py
+++ b/apps/jumpserver/settings/libs.py
@@ -101,7 +101,7 @@ CHANNEL_LAYERS = {
             "hosts": [{
                 'address': (CONFIG.REDIS_HOST, CONFIG.REDIS_PORT),
                 'db': CONFIG.REDIS_DB_WS,
-                'password': CONFIG.REDIS_PASSWORD,
+                'password': CONFIG.REDIS_PASSWORD or None,
                 'ssl':  context
             }],
         },


### PR DESCRIPTION
fix: 修复部署JumpServer在没有密码的redis上时，站内信数量不更新问题