### PR TITLE
Fix issue #8287 with blank SAML's RelayState

### DIFF
--- a/apps/authentication/backends/saml2/views.py
+++ b/apps/authentication/backends/saml2/views.py
@@ -271,7 +271,10 @@ class Saml2AuthCallbackView(View, PrepareRequestMixin):
             auth.login(self.request, user)
 
         logger.debug(log_prompt.format('Redirect'))
-        next_url = saml_instance.redirect_to(post_data.get('RelayState', '/'))
+        redir = post_data.get('RelayState')
+        if not redir or len(redir) == 0:
+          redir = "/"
+        next_url = saml_instance.redirect_to(redir)
         return HttpResponseRedirect(next_url)
 
     @csrf_exempt


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes issue #8287

#### Summary of your change

Dumbly fixes redirect an empty URLs when the IDP sends blank RelayStates.
This fix was verified on two different Jumpservers.