### PR TITLE
Support signing SAML Request

### DIFF
--- a/apps/authentication/backends/saml2/views.py
+++ b/apps/authentication/backends/saml2/views.py
@@ -159,7 +159,7 @@ class PrepareRequestMixin:
         sp_settings.update(advanced_settings)
 
         # load sp cert and key for encryption if advanced_settings.security.authnRequestsSigned is True
-        if advanced_settings.get('authnRequestsSigned'):
+        if advanced_settings.get('security') and advanced_settings.get('security').get('authnRequestsSigned'):
             certs = {
                 "privateKey": settings.SAML2_SP_KEY_CONTENT,
                 "x509cert": settings.SAML2_SP_CERT_CONTENT

--- a/apps/authentication/backends/saml2/views.py
+++ b/apps/authentication/backends/saml2/views.py
@@ -159,7 +159,7 @@ class PrepareRequestMixin:
         sp_settings.update(advanced_settings)
 
         # load sp cert and key for encryption if advanced_settings.security.authnRequestsSigned is True
-        if advanced_settings['authnRequestsSigned']:
+        if advanced_settings.get('authnRequestsSigned'):
             certs = {
                 "privateKey": settings.SAML2_SP_KEY_CONTENT,
                 "x509cert": settings.SAML2_SP_CERT_CONTENT


### PR DESCRIPTION

#### What this PR does / why we need it?
Support sign SAML Request(which is turned off now and can't be turned on)

#### Summary of your change
1. signing turned on by setting 
         'authnRequestsSigned': true 
   in advanced settings on web console

2. signAlgorithm is default to 'http://www.w3.org/2000/09/xmldsig#rsa-sha1', can be specified by setting 
        'signatureAlgorithm': {your_algo} 
  in advanced settings on web console

3. if signing turned on, sp cert and key must be uploaded first on web console

#### Please indicate you've done the following:

- [Y] Made sure tests are passing and test coverage is added if needed.
- [Y] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [Y] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.