### PR TITLE
fix: 解决JobLog表依赖顺序不对，导致从新迁移失败问题

### DIFF
--- a/apps/audits/migrations/0021_auto_20230207_0857.py
+++ b/apps/audits/migrations/0021_auto_20230207_0857.py
@@ -8,6 +8,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('audits', '0020_auto_20230117_1004'),
+        ('ops', '0023_auto_20220912_0021'),
     ]
 
     operations = [


### PR DESCRIPTION
fix: 解决JobLog表依赖顺序不对，导致从新迁移失败问题