### PR TITLE
fix: SyntaxWarning, apps/common/drf/parsers/base.py:114, "is" should be "=="

### DIFF
--- a/apps/common/drf/parsers/base.py
+++ b/apps/common/drf/parsers/base.py
@@ -111,7 +111,7 @@ class BaseFileParser(BaseParser):
         return {'pk': obj_id, 'name': obj_name}
 
     def parse_value(self, field, value):
-        if value is '-':
+        if value == '-':
             return None
         elif hasattr(field, 'to_file_internal_value'):
             value = field.to_file_internal_value(value)


### PR DESCRIPTION
#### What this PR does / why we need it?
Fix SyntaxWarning

#### Summary of your change
fix: SyntaxWarning, apps/common/drf/parsers/base.py:114, "is" should be "=="

#### Please indicate you've done the following:

- [✓] Made sure tests are passing and test coverage is added if needed.
- [✓ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ✓] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.