### PR TITLE
fix: type object 'Status' has no attribute 'get_terminal_latest_stat'

### DIFF
--- a/apps/ops/notifications.py
+++ b/apps/ops/notifications.py
@@ -6,7 +6,8 @@ from notifications.notifications import SystemMessage
 from notifications.models import SystemMsgSubscription
 from users.models import User
 from notifications.backends import BACKEND
-from terminal.models import Status, Terminal
+from terminal.models.component.status import Status
+from terminal.models import Terminal
 
 __all__ = ('ServerPerformanceMessage', 'ServerPerformanceCheckUtil')
 


### PR DESCRIPTION
AttributeError: type object 'Status' has no attribute 'get_terminal_latest_stat'

#### What this PR does / why we need it?
fix AttributeError

#### Summary of your change
change import module name to below

from terminal.models.component.status import Status
from terminal.models import Terminal

#### Please indicate you've done the following:

- [✓] Made sure tests are passing and test coverage is added if needed.
- [✓] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [✓] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.