### PR TITLE
fix a latent bug when field_type belongs to int, bool and list.

### DIFF
--- a/apps/common/serializers/dynamic.py
+++ b/apps/common/serializers/dynamic.py
@@ -62,6 +62,8 @@ def create_serializer_class(serializer_name, fields_info):
             data['required'] = False
         data = set_default_by_type(field_type, data, field_info)
         data = set_default_if_need(data, i)
+        if field_type in ['int', 'bool', 'list'] and "allow_blank" in data.keys():
+            data.pop('allow_blank')
         field_name = data.pop('name')
         field_class = type_field_map.get(field_type, serializers.CharField)
         serializer_fields[field_name] = field_class(**data)


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR aims at solving a latent bug when `filed_type` belongs to `int`, `bool` and `list`. This bug will cause errors when someone choose to deploy customized/official jumpserver from code.

#### Summary of your change
The `serializers.IntegerField`, `serializers.ListField`, and `serializers.BooleanField` don't pop the argument named `allow_blank` out and the `Field` class they inherit don't accept such an argument, so that this argument should be pop out when `field_type` is `int`, `bool`, `list`. Thus, I add two lines of codes to pop `allow_blank` when `field_type` exists in `data` and belongs to the type of `int`, `bool`, `list`, to avoid this error.
Details of `Field`, `IntegerField`, `ListField`, `BooleanField` can be refer to https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/fields.py

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.