### PR TITLE
fix: 修复飞书markdown信息渲染问题

### DIFF
--- a/apps/common/sdk/im/feishu/__init__.py
+++ b/apps/common/sdk/im/feishu/__init__.py
@@ -117,8 +117,8 @@ class FeiShu(RequestMixin):
         }
 
         body = {
-            'msg_type': 'text',
-            'content': json.dumps({'text': msg})
+            'msg_type': 'interactive',
+            'content': json.dumps({'elements':[{'tag':'markdown','content': msg}]})
         }
 
         invalid_users = []


### PR DESCRIPTION
修复前:  
![image](https://github.com/jumpserver/jumpserver/assets/25497484/dec3c8ed-9df5-434f-a9cb-63daf7a261a2)


修复后:  
![image](https://github.com/jumpserver/jumpserver/assets/25497484/7eb7ba56-d73e-4541-b617-d2e004e03239)
