### PR TITLE
指定lxml版本为4.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ openai = "^1.3.7"
 xlsxwriter = "^3.1.9"
 exchangelib = "^5.1.0"
 xmlsec = "^1.3.13"
+lxml = "4.9.3"
 
 
 [tool.poetry.group.xpack.dependencies]


### PR DESCRIPTION
修复SAML2认证回调/core/auth/saml2/callback/时偶发出现http 502错误
Keycloak认证成功回调jumpserver的接口/core/auth/saml2/callback/时会响应SAMLResponse，响应数据为XML格式
下图为gunicorn.log中记录的日志，在收到saml response后，worker异常退出，并重启worker
![image](https://github.com/jumpserver/jumpserver/assets/14314203/bc1dce14-77e0-45a2-85ed-6d8316473bbb)

此时nginx返回502并记录了错误日志
![image](https://github.com/jumpserver/jumpserver/assets/14314203/7924e11c-1d9d-4c0b-8fd0-c822e0dd64c4)


参考：https://github.com/SAML-Toolkits/python3-saml/issues/396