### PR TITLE
fix: 主机硬件信息硬盘大小避免多次挂载重复计入

### DIFF
--- a/apps/assets/automations/gather_facts/host/posix/main.yml
+++ b/apps/assets/automations/gather_facts/host/posix/main.yml
@@ -12,7 +12,12 @@
           cpu_cores: "{{ ansible_processor_cores }}"
           cpu_vcpus: "{{ ansible_processor_vcpus }}"
           memory: "{{ ansible_memtotal_mb / 1024 | round(2) }}"
-          disk_total: "{{ (ansible_mounts | map(attribute='size_total') | sum / 1024 / 1024 / 1024) | round(2) }}"
+          disk_total: |-
+            {% set ns = namespace(total=0) %}
+            {%- for name, dev in ansible_devices.items() if dev.removable == '0' and dev.host != ''  -%}
+              {%- set ns.total = ns.total + ( dev.sectors | int * dev.sectorsize | int ) -%}
+            {%- endfor -%}
+            {{- (ns.total / 1024 / 1024 / 1024) | round(2) -}}
           distribution: "{{ ansible_distribution }}"
           distribution_version: "{{ ansible_distribution_version }}"
           arch: "{{ ansible_architecture }}"


### PR DESCRIPTION
#### What this PR does / why we need it?

多个不同路径挂载相同硬盘时现在的统计方式也会导致多次计入硬盘大小。

调整后只按设备口径计算非可插拔的(u盘等removable为'0')、关联物理设备的(逻辑卷等设备host为'')大小，避免重复计算，也不计入nfs等挂载大小，更符合实际主机硬盘大小。

同时，也避免目前硬盘大小计算时，如有docker直接向容器内挂载nfs等场景会ansible取不到size_total，导致整个硬件信息都获取失败的情况

```
 FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'size_total'.
```

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.