### PR TITLE
fix: Ensure memory units for Windows host hardware information are consistent with other hosts; align CPU information fields with other hosts.

### DIFF
--- a/apps/assets/automations/gather_facts/host/windows/main.yml
+++ b/apps/assets/automations/gather_facts/host/windows/main.yml
@@ -11,8 +11,10 @@
           vendor: "{{ ansible_system_vendor }}"
           model: "{{ ansible_product_name }}"
           sn: "{{ ansible_product_serial }}"
+          cpu_count: "{{ ansible_processor_count }}"
+          cpu_cores: "{{ ansible_processor_cores }}"
           cpu_vcpus: "{{ ansible_processor_vcpus }}"
-          memory: "{{ ansible_memtotal_mb }}"
+          memory: "{{ (ansible_memtotal_mb / 1024) | round(2) }}"
 
     - debug:
         var: info


### PR DESCRIPTION
#### What this PR does / why we need it?

解决windows主机硬件信息在列表展示时不显示问题：

* windows主机获取硬件信息后cpu信息记录字段不全，导致列表显示硬件信息时windows主机整个字段都显示不出来

* windows主机获取硬件信息后内存单位与posix主机单位不一致，列表显示出来后内存大小单位错误

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.