### PR TITLE
perf: 企业版隐藏页脚的 Copyright 信息

### DIFF
--- a/apps/templates/_copyright.html
+++ b/apps/templates/_copyright.html
@@ -1,3 +1,3 @@
-{% if not USE_XPACK %}
+{% if not XPACK_ENABLED %}
 <strong>Copyright</strong> {{ COPYRIGHT }}
 {% endif %}


### PR DESCRIPTION
企业版隐藏页脚的 Copyright 信息

#### What this PR does / why we need it?
当前 v3.10.x 版本中企业版登录进行 MFA 二次认证时，无法隐藏页脚的 “Copyright FIT2CLOUD 飞致云 © 2014-2024“ 内容

<img width="691" alt="image" src="https://github.com/jumpserver/jumpserver/assets/95400700/0040d520-0b81-48bf-a9ea-a43ec4676eac">


