### PR TITLE
perf: Enterprise Edition Hide Footer Copyright Content

### DIFF
--- a/apps/templates/_copyright.html
+++ b/apps/templates/_copyright.html
@@ -1,3 +1,3 @@
-{% if not USE_XPACK %}
+{% if not XPACK_ENABLED %}
 <strong>Copyright</strong> {{ COPYRIGHT }}
 {% endif %}


### PR DESCRIPTION
#### What this PR does / why we need it?
When logging in to the Enterprise Edition for MFA secondary authentication, the "Copyright FIT2CLOUD © 2014-2024" content in the footer cannot be hidden.

#### Summary of your change
![image](https://github.com/jumpserver/jumpserver/assets/95400700/f9e3c32d-3089-495a-aab7-616548fa48b1)
