### PR TITLE
perf: Enterprise Edition Hide Footer Copyright Content

### DIFF
--- a/apps/templates/_copyright.html
+++ b/apps/templates/_copyright.html
@@ -1,3 +1,3 @@
-{% if not USE_XPACK %}
+{% if not XPACK_ENABLED %}
 <strong>Copyright</strong> {{ COPYRIGHT }}
 {% endif %}


### PR DESCRIPTION
#### What this PR does / why we need it?
企业版登录进行 MFA 二次认证时，无法隐藏页脚的 “Copyright FIT2CLOUD 飞致云 © 2014-2024“ 内容

![image](https://github.com/jumpserver/jumpserver/assets/95400700/b14276c5-6d0c-4040-bd99-528bbd352181)