### PR TITLE
Fix the abnormal issue of client IP acquisition when implementing X-Forwarded-For non-standard methods

### DIFF
--- a/apps/common/utils/common.py
+++ b/apps/common/utils/common.py
@@ -158,7 +158,7 @@ def is_uuid(seq):
 def get_request_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR', '').split(',')
     if x_forwarded_for and x_forwarded_for[0]:
-        login_ip = x_forwarded_for[0]
+        login_ip = x_forwarded_for[0].split(":")[0]
         return login_ip
 
     login_ip = request.META.get('REMOTE_ADDR', '')
@@ -293,7 +293,7 @@ def get_docker_mem_usage_if_limit():
             inactive_file = int(inactive_file)
         return ((usage_in_bytes - inactive_file) / limit_in_bytes) * 100
 
-    except Exception as e:
+    except Exception:
         return None
 
 

--- a/apps/common/utils/http.py
+++ b/apps/common/utils/http.py
@@ -39,10 +39,6 @@ def iso8601_to_unixtime(time_string):
     return to_unixtime(time_string, _ISO8601_FORMAT)
 
 
-def get_remote_addr(request):
-    return request.META.get("HTTP_X_FORWARDED_HOST") or request.META.get("REMOTE_ADDR")
-
-
 def is_true(value):
     return value in BooleanField.TRUE_VALUES
 


### PR DESCRIPTION
#### What this PR does / why we need it?
the X-Forwarded-For header is not formally standardized, some variations to the IP address format exist. For example, some implementations include the port number of clients
```
X-Forwarded-For: 203.0.113.195:41237, 198.51.100.100:38523
```
#### Summary of your change
Fix the abnormal issue of client IP acquisition when implementing X-Forwarded-For non-standard methods
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.