### PR TITLE
fix: fixed the issue that websocket cannot use "Authorization" header

### DIFF
--- a/apps/jumpserver/routing.py
+++ b/apps/jumpserver/routing.py
@@ -33,17 +33,17 @@ def get_signature_user(scope):
         return
     if scope['type'] == 'websocket':
         scope['method'] = 'GET'
-    try:
-        # 因为 ws 使用的是 scope，所以需要转换成 request 对象，用于认证校验
-        request = ASGIRequest(scope, None)
-        backends = [SignatureAuthentication(),
-                    AccessTokenAuthentication()]
-        for backend in backends:
+    # 因为 ws 使用的是 scope，所以需要转换成 request 对象，用于认证校验
+    request = ASGIRequest(scope, None)
+    backends = [SignatureAuthentication(),
+                AccessTokenAuthentication()]
+    for backend in backends:
+        try:
             user, _ = backend.authenticate(request)
             if user:
                 return user
-    except Exception as e:
-        print(e)
+        except Exception as e:
+            print(e)
     return None
 
 


### PR DESCRIPTION
When using the ```ws://jumpserver.com/ws/ops/tasks/log/``` api, if an Authorization Header is passed into the api, the websocket connection will fail.

An error will happen when calling the authentication method in SignatureAuthentication, the authentication method in AccessTokenAuthentication will not be executed, and ultimately the authentication will fail.