### PR TITLE
Resolve warnings of logger library

### DIFF
--- a/apps/assets/models/zone.py
+++ b/apps/assets/models/zone.py
@@ -39,7 +39,7 @@ class Zone(LabeledMixin, JMSOrgBaseModel):
         if not gateways:
             gateways = self.active_gateways
         if not gateways:
-            logger.warn(f'Not active gateway, domain={self}, pass')
+            logger.warning(f'Not active gateway, domain={self}, pass')
             return None
         return random.choice(gateways)
 

--- a/apps/assets/pagination.py
+++ b/apps/assets/pagination.py
@@ -32,7 +32,7 @@ class AssetPaginationBase(LimitOffsetPagination):
         }
         for k, v in self._request.query_params.items():
             if k not in exclude_query_params and v is not None:
-                logger.warn(f'Not hit node.assets_amount because find a unknown query_param '
+                logger.warning(f'Not hit node.assets_amount because find a unknown query_param '
                             f'`{k}` -> {self._request.get_full_path()}')
                 return super().get_count(queryset)
         node_assets_count = self.get_count_from_nodes(queryset)

--- a/apps/assets/tasks/utils.py
+++ b/apps/assets/tasks/utils.py
@@ -25,10 +25,10 @@ def check_asset_can_run_ansible(asset):
 
 def check_system_user_can_run_ansible(system_user):
     if not system_user.auto_push_account:
-        logger.warn(f'Push system user task skip, auto push not enable: system_user={system_user.name}')
+        logger.warning(f'Push system user task skip, auto push not enable: system_user={system_user.name}')
         return False
     if not system_user.is_protocol_support_push:
-        logger.warn(f'Push system user task skip, protocol not support: '
+        logger.warning(f'Push system user task skip, protocol not support: '
                     f'system_user={system_user.name} protocol={system_user.protocol} '
                     f'support_protocol={system_user.SUPPORT_PUSH_PROTOCOLS}')
         return False

--- a/apps/authentication/mixins.py
+++ b/apps/authentication/mixins.py
@@ -174,7 +174,7 @@ class AuthPreCheckMixin:
         is_block = LoginBlockUtil(username, ip).is_block()
         if not is_block:
             return
-        logger.warn('Ip was blocked' + ': ' + username + ':' + ip)
+        logger.warning('Ip was blocked' + ': ' + username + ':' + ip)
         exception = errors.BlockLoginError(username=username, ip=ip)
         if raise_exception:
             raise errors.BlockLoginError(username=username, ip=ip)
@@ -253,7 +253,7 @@ class MFAMixin:
         blocked = MFABlockUtils(username, ip).is_block()
         if not blocked:
             return
-        logger.warn('Ip was blocked' + ': ' + username + ':' + ip)
+        logger.warning('Ip was blocked' + ': ' + username + ':' + ip)
         exception = errors.BlockMFAError(username=username, request=self.request, ip=ip)
         if raise_exception:
             raise exception

--- a/apps/common/cache.py
+++ b/apps/common/cache.py
@@ -111,7 +111,7 @@ class Cache(metaclass=CacheType):
                 value = self[field].to_internal_value(v.decode())
                 internal_data[field] = value
             else:
-                logger.warn(f'Cache got invalid field: '
+                logger.warning(f'Cache got invalid field: '
                             f'key={self.key} '
                             f'invalid_field={field} '
                             f'valid_fields={self.field_names}')

--- a/apps/common/sdk/im/wecom/__init__.py
+++ b/apps/common/sdk/im/wecom/__init__.py
@@ -155,7 +155,7 @@ class WeCom(RequestMixin):
 
         errcode = data['errcode']
         if errcode == ErrorCode.INVALID_CODE:
-            logger.warn(f'WeCom get_user_id_by_code invalid code: code={code}')
+            logger.warning(f'WeCom get_user_id_by_code invalid code: code={code}')
             return None, None
 
         self._requests.check_errcode_is_0(data)

--- a/apps/ops/signal_handlers.py
+++ b/apps/ops/signal_handlers.py
@@ -137,7 +137,7 @@ def task_sent_handler(headers=None, body=None, **kwargs):
         args = json.loads(json.dumps(list(args), cls=JSONEncoder))
         kwargs = json.loads(json.dumps(kwargs, cls=JSONEncoder))
     except Exception as e:
-        logger.warn('Parse task args or kwargs error (Need handle): {}'.format(e))
+        logger.warning('Parse task args or kwargs error (Need handle): {}'.format(e))
         args = []
         kwargs = {}
 

--- a/apps/ops/ws.py
+++ b/apps/ops/ws.py
@@ -147,7 +147,7 @@ class TaskLogWebsocket(AsyncJsonWebsocketConsumer):
                             break
                     await asyncio.sleep(0.2)
         except OSError as e:
-            logger.warn('Task log path open failed: {}'.format(e))
+            logger.warning('Task log path open failed: {}'.format(e))
 
     async def disconnect(self, close_code):
         self.disconnected = True

--- a/apps/perms/pagination.py
+++ b/apps/perms/pagination.py
@@ -24,7 +24,7 @@ class NodePermedAssetPagination(GrantedAssetPaginationBase):
                          f'{self._request.get_full_path()}')
             return node.assets_amount
         else:
-            logger.warn(f'Not hit node.assets_amount[{node}] because {self._view} '
+            logger.warning(f'Not hit node.assets_amount[{node}] because {self._view} '
                         f'not has `pagination_node` -> {self._request.get_full_path()}')
             return None
 

--- a/apps/terminal/backends/__init__.py
+++ b/apps/terminal/backends/__init__.py
@@ -32,7 +32,7 @@ def get_terminal_command_storages():
     storage_list = {}
     for s in CommandStorage.objects.all():
         if not s.is_valid():
-            logger.warn(f'Command storage invalid: storage={s}')
+            logger.warning(f'Command storage invalid: storage={s}')
             continue
 
         if s.type_server:


### PR DESCRIPTION
#### PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.