### PR TITLE
perf: ES command log supports fuzzy search

### DIFF
--- a/apps/audits/backends/es.py
+++ b/apps/audits/backends/es.py
@@ -35,6 +35,7 @@ class OperateLogStore(ES, metaclass=Singleton):
             }
         }
         exact_fields = {}
+        fuzzy_fields = {}
         match_fields = {
             'id', 'user', 'action', 'resource_type',
             'resource', 'remote_addr', 'org_id'
@@ -44,7 +45,7 @@ class OperateLogStore(ES, metaclass=Singleton):
         }
         if not config.get('INDEX'):
             config['INDEX'] = 'jumpserver_operate_log'
-        super().__init__(config, properties, keyword_fields, exact_fields, match_fields)
+        super().__init__(config, properties, keyword_fields, exact_fields, fuzzy_fields, match_fields)
         self.pre_use_check()
 
     @staticmethod

--- a/apps/terminal/backends/command/es.py
+++ b/apps/terminal/backends/command/es.py
@@ -27,11 +27,12 @@ class CommandStore(ES):
                 "type": "long"
             }
         }
-        exact_fields = {'input', 'risk_level', 'user', 'asset', 'account'}
+        exact_fields = {}
+        fuzzy_fields = {'input', 'risk_level', 'user', 'asset', 'account'}
         match_fields = {'input'}
         keyword_fields = {'session', 'org_id'}
 
-        super().__init__(config, properties, keyword_fields, exact_fields, match_fields)
+        super().__init__(config, properties, keyword_fields, exact_fields, fuzzy_fields, match_fields)
 
     @staticmethod
     def make_data(command):


### PR DESCRIPTION
#### What this PR does / why we need it?
命令记录ES 搜索，指定字段完全匹配优化为模糊匹配，与数据库搜索对齐

数据库搜索效果如下（按字段模糊匹配）：
![image](https://github.com/user-attachments/assets/73488884-6b3e-45bf-aca9-ff83be0d204b)
