### PR TITLE
docs(en_US/sso): add English SAML SSO guide with Okta example

### DIFF
--- a/docs/en_US/sso/saml.md
+++ b/docs/en_US/sso/saml.md
@@ -1,0 +1,20 @@
+# SAML SSO Configuration for JumpServer (English)
+
+## SAML Setup
+
+SAML (Security Assertion Markup Language) allows single sign-on with identity providers like Okta or Azure AD.
+
+### General Steps
+1. Enable SAML in JumpServer settings.
+2. Upload IdP metadata (from your provider).
+3. Configure entity ID and ACS URL.
+4. Test user login.
+
+### Okta SAML Integration Example
+1. In Okta, create a new SAML app.
+2. Set **Single sign on URL**: `https://your-jumpserver.com/sso/saml/acs/`
+3. Set **Audience URI**: `https://your-jumpserver.com/sso/saml/metadata/`
+4. Download IdP metadata and upload to JumpServer → Settings → SSO.
+5. Test login via Okta.
+
+For more, see the main Chinese docs: [SAML Guide](saml.md).


### PR DESCRIPTION
Adds a simple English SAML SSO guide with a 5-step Okta example to help non-Chinese users configure faster.

- New file: 'docs/en_US/sso/saml.md'
- No code changes. Demo-safe.
- Links to main Chinese docs for completeness.