### PR TITLE
fix: CAS login infinite loop when user is disabled

### DIFF
--- a/apps/authentication/backends/cas/views.py
+++ b/apps/authentication/backends/cas/views.py
@@ -1,5 +1,7 @@
+from django.contrib.auth import logout as auth_logout
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django_cas_ng.views import LoginView
 
@@ -16,7 +18,11 @@ class CASLoginView(LoginView, FlashMessageMixin):
             resp = HttpResponseRedirect('/')
         error_message = getattr(request, 'error_message', '')
         if error_message:
-            response = self.get_failed_response('/', title=_('CAS Error'), msg=error_message)
+            auth_logout(request)
+            redirect_url = reverse('authentication:login') + '?admin=1'
+            response = self.get_failed_response(
+                redirect_url, title=_('CAS Error'), msg=error_message
+            )
             return response
         else:
             return resp


### PR DESCRIPTION
## Summary

- Fix infinite redirect loop when a disabled (`is_active=False`) user logs in via CAS
- Call `auth_logout(request)` to clear the invalid session established by `django_cas_ng`
- Redirect to login page with `?admin=1` instead of `/` to prevent automatic CAS re-authentication

## Background

When CAS Server authenticates successfully but the local JumpServer user is disabled:
1. `django_cas_ng` calls `login()` establishing a session
2. `CASLoginView` detects the error and shows an error page redirecting to `/`
3. The user is treated as anonymous → redirected to login → auto-redirected to CAS → CAS session still valid → loop

The same issue was fixed for OAuth2 in [`680c174dc`](https://github.com/jumpserver/jumpserver/commit/680c174dc) but was missed for CAS.