### PR TITLE
fix(oidc): add support for nested params claim from OIDC providers

### DIFF
--- a/apps/authentication/backends/oidc/backends.py
+++ b/apps/authentication/backends/oidc/backends.py
@@ -41,6 +41,13 @@ class UserMixin:
 
         sub = claims['sub']
 
+        # Flatten nested 'params' claim into top-level claims so that
+        # provider-specific custom parameters (e.g. OneLogin) are accessible
+        # via AUTH_OPENID_USER_ATTR_MAP.
+        params = claims.get('params')
+        if isinstance(params, dict):
+            claims.update(params)
+
         # Construct user attrs value
         user_attrs = {}
         for field, attr in settings.AUTH_OPENID_USER_ATTR_MAP.items():

--- a/apps/authentication/backends/oidc/views.py
+++ b/apps/authentication/backends/oidc/views.py
@@ -134,6 +134,7 @@ class OIDCAuthCallbackView(View, FlashMessageMixin):
         logger.debug(log_prompt.format('Start'))
         callback_params = request.GET
         error_title = _("OpenID Error")
+        user = None
 
         # Retrieve the state value that was previously generated. No state means that we cannot
         # authenticate the user (so a failure should be returned).


### PR DESCRIPTION
## Summary
- Flatten the nested `params` claim into top-level claims in `get_or_create_user_from_claims()`. OIDC providers like OneLogin return custom parameters (e.g. `login_name`, `groups`) under a nested `params` dict. The current code only does flat claim lookups, so these custom parameters are silently missed and fall back to `sub`.
- Fix `UnboundLocalError` in `OIDCAuthCallbackView.get()` where `user` was referenced before assignment when the authentication flow skipped the `auth.authenticate()` code path.

## Test plan
- [x] Configure an OIDC provider (e.g. OneLogin) with custom parameters under the `params` scope
- [x] Set `AUTH_OPENID_USER_ATTR_MAP` to reference a custom param (e.g. `{"username": "login_name"}`)
- [x] Verify login creates/maps the user with the correct custom param value
- [x] Verify OIDC callback no longer returns 500 on auth failure