### PR TITLE
fix: enhance account selection logic in Applet model

### DIFF
--- a/apps/terminal/models/applet/applet.py
+++ b/apps/terminal/models/applet/applet.py
@@ -258,12 +258,14 @@ class Applet(JMSBaseModel):
 
     accounts_using_key_tmpl = 'applet_host_accounts_{}_{}_{}'
 
-    def select_a_public_account(self, user, host, valid_accounts):
+    def select_a_public_account(self, user, host, valid_accounts, only_jms_prefix=False):
         using_keys = cache.keys(self.accounts_using_key_tmpl.format(host.id, '*', '*')) or []
         accounts_username_used = list(cache.get_many(using_keys).values())
         logger.debug('Applet host account using: {}: {}'.format(host.name, accounts_username_used))
         accounts = valid_accounts.exclude(username__in=accounts_username_used)
         public_accounts = accounts.filter(username__startswith='jms_')
+        if only_jms_prefix:
+            return self.random_select_prefer_account(user, host, public_accounts)
         if not public_accounts:
             public_accounts = accounts \
                 .exclude(username__in=['Administrator', 'root']) \
@@ -346,10 +348,15 @@ class Applet(JMSBaseModel):
             return None
         logger.info('Select applet host: {}'.format(host.name))
         valid_accounts = host.accounts.all().filter(privileged=False)
-        account = self.try_to_use_private_account(user, host, valid_accounts)
-        if not account:
-            logger.debug('No private account, try to use public account')
-            account = self.select_a_public_account(user, host, valid_accounts)
+        username_has_at = '@' in (user.username or '')
+        if username_has_at:
+            logger.debug('Username contains @, force use jms_ public account')
+            account = self.select_a_public_account(user, host, valid_accounts, only_jms_prefix=True)
+        else:
+            account = self.try_to_use_private_account(user, host, valid_accounts)
+            if not account:
+                logger.debug('No private account, try to use public account')
+                account = self.select_a_public_account(user, host, valid_accounts)
 
         if not account:
             logger.debug('No available account for applet host: {}'.format(host.name))


### PR DESCRIPTION
#### What this PR does / why we need it?
When the username contains @, the remote application selects jms_account login.
#### Summary of your change
A public-account filtering parameter has been added. When the username contains `@`, the connection uses the public account to avoid Windows mistakenly recognizing it as a domain account. When the username does not contain `@`, the logic remains unchanged.
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.