### PR TITLE
fix: inverted return value in SessionSharing.is_expired

### DIFF
--- a/apps/terminal/models/session/sharing.py
+++ b/apps/terminal/models/session/sharing.py
@@ -75,13 +75,13 @@ class SessionSharing(JMSBaseModel, OrgModelMixin):
     @property
     def is_expired(self) -> bool:
         if timezone.now() > self.date_expired:
-            return False
-        return True
+            return True
+        return False
 
     def can_join(self, joiner):
         if not self.is_active:
             return False, _('Link not active')
-        if not self.is_expired:
+        if self.is_expired:
             return False, _('Link expired')
         if self.users and str(joiner.id) not in self.users.split(','):
             return False, _('User not allowed to join')


### PR DESCRIPTION
## Bug Description

`SessionSharing.is_expired` returns `False` when the sharing link has expired and `True` when it has not — the exact opposite of what the property name indicates.

**File:** `apps/terminal/models/session/sharing.py:76-79`

```python
@property
def is_expired(self) -> bool:
    if timezone.now() > self.date_expired:
        return False  # ← expired, but returns False
    return True       # ← not expired, but returns True
```

This is inconsistent with every other `is_expired` implementation in the codebase:

| Model | `now > date_expired` returns | Correct? |
|---|---|---|
| `User` | `True` | ✅ |
| `ConnectionToken` | `True` | ✅ |
| `AssetPermission` | `True` | ✅ |
| **`SessionSharing`** | **`False`** | ❌ |

## Why it hasn't caused visible issues

The only caller `can_join()` uses double negation that accidentally produces correct behavior:

```python
if not self.is_expired:        # not False = True when expired
    return False, _("Link expired")  # correctly rejects
```

However, any new code that calls `is_expired` directly will get the wrong answer.

## Root Cause

The bug was introduced when the file was first created in commit `943b13003` (2022-10-22, "feat: 添加远程应用"). It has existed since day one.

## Fix

- `is_expired`: swap return values so `True` means expired
- `can_join`: `if not self.is_expired` → `if self.is_expired`

**No behavior change** — runtime logic is identical, only the semantics are corrected.
