### PR TITLE
fix: command injection via subprocess string in DBeaver applet

### DIFF
--- a/apps/terminal/applets/dbeaver/app.py
+++ b/apps/terminal/applets/dbeaver/app.py
@@ -148,7 +148,7 @@ class AppletApplication(BaseApplication):
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags = subprocess.CREATE_NEW_CONSOLE | subprocess.STARTF_USESHOWWINDOW
         startupinfo.wShowWindow = subprocess.SW_HIDE
-        exec_string = '%s -con %s' % (self.path, params)
+        exec_string = [self.path, '-con', params]
         ret = subprocess.Popen(exec_string, startupinfo=startupinfo)
         self.pid = ret.pid
 


### PR DESCRIPTION
## Bug Description

`AppletApplication.run()` passes a format string to `subprocess.Popen()`:

```python
exec_string = '%s -con %s' % (self.path, params)
ret = subprocess.Popen(exec_string, startupinfo=startupinfo)
```

On Windows, `Popen(string)` invokes `cmd.exe` to parse the command. The `params` string contains user-controlled values (asset address, database name, username, password) that are not sanitized.

**File:** `apps/terminal/applets/dbeaver/app.py:151-152`

## Risk

`cmd.exe` interprets shell metacharacters in the params string:
- `|` — pipe (also used as DBeaver's parameter delimiter)
- `&` — command chaining
- `>` — output redirection

If an attacker sets a database password to `abc&calc`, the resulting command becomes:

```
C:\dbeaver\dbeaver.exe -con ...password=abc&calc
```

`cmd.exe` executes this as two commands:
1. `dbeaver.exe -con ...password=abc`
2. `calc` (arbitrary command execution)

This is **remote code execution on the Windows Applet Host**. Any user-controlled field (password, username, database name, host) can be used as an injection vector.

## Fix

Pass a list to `Popen()` instead of a string. On Windows this uses `CreateProcess` directly, bypassing `cmd.exe` — shell metacharacters are treated as literal characters.

```python
# Before: string -> cmd.exe parses metacharacters
exec_string = '%s -con %s' % (self.path, params)

# After: list -> CreateProcess, no shell interpretation
exec_string = [self.path, '-con', params]
```

No behavior change for normal inputs. DBeaver receives the same `-con` parameter string as before.
