### PR TITLE
feat: enhance VirtualAccount methods to support secret types and update connection token handling

### DIFF
--- a/apps/accounts/models/virtual.py
+++ b/apps/accounts/models/virtual.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-from accounts.const import AliasAccount
+from accounts.const import AliasAccount, SecretType
 from orgs.mixins.models import JMSOrgBaseModel
 
 __all__ = ['VirtualAccount']
@@ -54,13 +54,21 @@ class VirtualAccount(JMSOrgBaseModel):
         return cls.objects.all()
 
     @classmethod
-    def get_special_account(cls, alias, user, asset, input_username='', input_secret='', from_permed=True):
+    def get_special_account(
+            cls, alias, user, asset, input_username='', input_secret='',
+            input_secret_type=SecretType.PASSWORD, from_permed=True
+    ):
         if alias == AliasAccount.INPUT.value:
-            account = cls.get_manual_account(input_username, input_secret, from_permed)
+            account = cls.get_manual_account(
+                input_username, input_secret, input_secret_type, from_permed
+            )
         elif alias == AliasAccount.ANON.value:
             account = cls.get_anonymous_account()
         elif alias == AliasAccount.USER.value:
-            account = cls.get_same_account(user, asset, input_secret=input_secret, from_permed=from_permed)
+            account = cls.get_same_account(
+                user, asset, input_secret=input_secret,
+                input_secret_type=input_secret_type, from_permed=from_permed
+            )
         else:
             account = cls(name=alias, username=alias, secret=None)
         account.alias = alias
@@ -70,7 +78,10 @@ class VirtualAccount(JMSOrgBaseModel):
         return account
 
     @classmethod
-    def get_manual_account(cls, input_username='', input_secret='', from_permed=True):
+    def get_manual_account(
+            cls, input_username='', input_secret='',
+            input_secret_type=SecretType.PASSWORD, from_permed=True
+    ):
         """ @INPUT 手动登录的账号(any) """
         from .account import Account
         if from_permed:
@@ -79,7 +90,10 @@ class VirtualAccount(JMSOrgBaseModel):
         else:
             username = input_username
             secret = input_secret
-        return Account(name=AliasAccount.INPUT.label, username=username, secret=secret)
+        return Account(
+            name=AliasAccount.INPUT.label, username=username,
+            secret=secret, secret_type=input_secret_type
+        )
 
     @classmethod
     def get_anonymous_account(cls):
@@ -87,7 +101,10 @@ class VirtualAccount(JMSOrgBaseModel):
         return Account(name=AliasAccount.ANON.label, username=AliasAccount.ANON.value, secret=None)
 
     @classmethod
-    def get_same_account(cls, user, asset, input_secret='', from_permed=True):
+    def get_same_account(
+            cls, user, asset, input_secret='',
+            input_secret_type=SecretType.PASSWORD, from_permed=True
+    ):
         """ @USER 动态用户的账号(self) """
         from .account import Account
         username = user.username
@@ -102,6 +119,9 @@ class VirtualAccount(JMSOrgBaseModel):
 
         if not secret and not from_permed:
             secret = input_secret
-        account = Account(name=AliasAccount.USER.label, username=username, secret=secret)
+        account = Account(
+            name=AliasAccount.USER.label, username=username,
+            secret=secret, secret_type=input_secret_type
+        )
         account.alias = alias
         return account

--- a/apps/authentication/models/connection_token.py
+++ b/apps/authentication/models/connection_token.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import PermissionDenied
 
+from accounts.const import SecretType
 from accounts.models import VirtualAccount
 from assets.const import Protocol
 from assets.const.host import GATEWAY_NAME
@@ -298,15 +299,17 @@ class ConnectionToken(JMSOrgBaseModel):
         if not self.asset:
             return None
 
+        input_secret_type = self.connect_options.get('input_secret_type', SecretType.PASSWORD)
         if self.account.startswith('@'):
             account = VirtualAccount.get_special_account(
                 self.account, self.user, self.asset, input_username=self.input_username,
-                input_secret=self.input_secret, from_permed=False
+                input_secret=self.input_secret, input_secret_type=input_secret_type, from_permed=False
             )
         else:
             account = self.get_asset_accounts_by_alias(self.asset, self.account)
             if not account.secret and self.input_secret:
                 account.secret = self.input_secret
+                account.secret_type = input_secret_type
             self.set_ad_domain_if_need(account)
 
         return account

--- a/apps/i18n/luna/en.json
+++ b/apps/i18n/luna/en.json
@@ -208,6 +208,7 @@
     "Search": "Search",
     "Select account": "Select account",
     "SelectCommand": "Please select the command to execute.",
+    "SelectFile": "Select file",
     "Send command": "Send command",
     "Send text to all ssh terminals": "Send text to all ssh terminals",
     "SendCommandPlaceholder": "Input command here, Enter for new line, Ctrl+Enter to send",

--- a/apps/i18n/luna/es.json
+++ b/apps/i18n/luna/es.json
@@ -207,6 +207,7 @@
     "Search": "Buscar",
     "Select account": "Seleccionar cuenta",
     "SelectCommand": "Seleccione el comando a ejecutar",
+    "SelectFile": "Seleccionar archivo",
     "Send": "Enviar",
     "Send command": "Enviar comando",
     "Send text to all ssh terminals": "Enviar texto a todos los terminales SSH",

--- a/apps/i18n/luna/ja.json
+++ b/apps/i18n/luna/ja.json
@@ -207,6 +207,7 @@
     "Search": "検索",
     "Select account": "システムユーザーの選択",
     "SelectCommand": "実行するコマンドを選択してください",
+    "SelectFile": "ファイルを選択",
     "Send": "送信",
     "Send command": "コマンドを送信",
     "Send text to all ssh terminals": "すべてのssh端末にテキストを送信します",

--- a/apps/i18n/luna/ko.json
+++ b/apps/i18n/luna/ko.json
@@ -207,6 +207,7 @@
     "Search": "검색",
     "Select account": "계정 선택",
     "SelectCommand": "실행할 명령을 선택하세요",
+    "SelectFile": "파일 선택",
     "Send": "전송",
     "Send command": "명령 전송",
     "Send text to all ssh terminals": "모든 SSH 터미널로 텍스트 전송",

--- a/apps/i18n/luna/pt_br.json
+++ b/apps/i18n/luna/pt_br.json
@@ -207,6 +207,7 @@
     "Search": "Pesquisar",
     "Select account": "Selecionar conta",
     "SelectCommand": "Selecione o comando a ser executado",
+    "SelectFile": "Selecionar arquivo",
     "Send": "Enviar",
     "Send command": "Enviar comando",
     "Send text to all ssh terminals": "Enviar texto para todos os terminais ssh",

--- a/apps/i18n/luna/ru.json
+++ b/apps/i18n/luna/ru.json
@@ -207,6 +207,7 @@
     "Search": "Поиск",
     "Select account": "Выбрать УЗ",
     "SelectCommand": "Выберите команду для выполнения",
+    "SelectFile": "Выбрать файл",
     "Send": "Отправить",
     "Send command": "Отправить команду",
     "Send text to all ssh terminals": "Отправить текст на все ssh терминалы",

--- a/apps/i18n/luna/vi.json
+++ b/apps/i18n/luna/vi.json
@@ -207,6 +207,7 @@
     "Search": "Tìm kiếm",
     "Select account": "Chọn tài khoản",
     "SelectCommand": "Vui lòng chọn lệnh cần thực hiện",
+    "SelectFile": "Chọn tệp",
     "Send": "Gửi",
     "Send command": "Gửi lệnh",
     "Send text to all ssh terminals": "Gửi đến tất cả các cuộc hội thoại",

--- a/apps/i18n/luna/zh.json
+++ b/apps/i18n/luna/zh.json
@@ -207,6 +207,7 @@
     "Search": "搜索",
     "Select account": "选择账号",
     "SelectCommand": "请选择要执行的命令",
+    "SelectFile": "选择文件",
     "Send": "发送",
     "Send command": "发送命令",
     "Send text to all ssh terminals": "发送给所有会话",

--- a/apps/i18n/luna/zh_hant.json
+++ b/apps/i18n/luna/zh_hant.json
@@ -208,6 +208,7 @@
     "Search": "搜索",
     "Select account": "選擇帳號",
     "SelectCommand": "請選擇要執行的命令",
+    "SelectFile": "選擇檔案",
     "Send": "發送",
     "Send command": "發送命令",
     "Send text to all ssh terminals": "發送文本到所有ssh終端",


### PR DESCRIPTION
#### What this PR does / why we need it?

Web 终端连接 SSH 协议资产，手动输入账号时支持使用 SSH key 连接。

关联 issue: https://github.com/jumpserver/luna/pull/1524

#### Summary of your change

- 在 Luna 连接对话框增加 SSH key 输入框，在 connect_options 中传入 input_secret_type：https://github.com/jumpserver/luna/pull/1524
- 增加对应的多语言文本
- 后端接口中获取 connect_options 中的 input_secret_type 并配置为 virtual account 的 secret type

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.