### PR TITLE
fix: failure when changing network device passwords through a gateway

### DIFF
--- a/apps/accounts/automations/change_secret/custom/ssh/main.yml
+++ b/apps/accounts/automations/change_secret/custom/ssh/main.yml
@@ -40,6 +40,8 @@
         password: "{{ account.secret }}"
         commands: "{{ params.commands }}"
         first_conn_delay_time: "{{ first_conn_delay_time | default(0.5) }}"
+        gateway_args: "{{ jms_asset.ansible_ssh_common_args | default(None) }}"
+        old_ssh_version: "{{ jms_asset.old_ssh_version | default(False) }}"
       ignore_errors: true
       when: ping_info is succeeded
       register: change_info

--- a/apps/libs/ansible/modules_utils/custom_common.py
+++ b/apps/libs/ansible/modules_utils/custom_common.py
@@ -168,7 +168,7 @@ class SSHClient:
             self.client.connect(**self.connect_params)
             self.is_connect = True
             err_msg = self.switch_user()
-            self.after_runner_end()
+            # self.after_runner_end()
         except Exception as err:
             err_msg = str(err)
         return err_msg
@@ -199,6 +199,8 @@ class SSHClient:
                     output += received_output
         except Exception as e:
             error_msg = str(e)
+        finally:
+            self.after_runner_end()
         return output, error_msg
 
     def __del__(self):


### PR DESCRIPTION
#### What this PR does / why we need it?
Fixes a v3.10.21 issue where changing network device passwords through a gateway failed.

The root cause was that the password change step did not correctly pass the gateway parameters, and the gateway tunnel was closed before executing the password change command. As a result, subsequent command execution attempted to use an unavailable connection.
#### Summary of your change
- Fixed missing gateway parameters in the network device password change step.
- Fixed premature gateway tunnel cleanup before executing password change commands.
#### Please indicate you've done the following:

- [ x ] Made sure tests are passing and test coverage is added if needed.
- [ x ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ x ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.