### PR TITLE
fix: avoid empty query in oauth2 redirect uri

### DIFF
--- a/apps/authentication/backends/oauth2/views.py
+++ b/apps/authentication/backends/oauth2/views.py
@@ -28,7 +28,8 @@ class OAuth2AuthRequestView(View):
         redirect_uri = build_absolute_uri(
             request, path=reverse(settings.AUTH_OAUTH2_AUTH_LOGIN_CALLBACK_URL_NAME)
         )
-        redirect_uri = f"{redirect_uri}?{query}"
+        if query:
+            redirect_uri = f"{redirect_uri}?{query}"
 
         query_dict = {
             'client_id': settings.AUTH_OAUTH2_CLIENT_ID, 'response_type': 'code',


### PR DESCRIPTION
#### What this PR does / why we need it?
Fixes an OAuth2 login issue where JumpServer generated a callback `redirect_uri` with a trailing `?` when there were no extra query parameters.
#### Summary of your change
Only append the query string to the OAuth2 callback `redirect_uri` when the query string is not empty.
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.