### PR TITLE
fix: resolve SFTP storage SSH key parsing failure

### DIFF
--- a/apps/common/storage/jms_storage/sftp.py
+++ b/apps/common/storage/jms_storage/sftp.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import io
 import os
 
 import paramiko
+
+from common.utils.encode import ssh_key_string_to_obj
 
 from .base import ObjectStorage
 
@@ -27,9 +28,11 @@ class SFTPStorage(ObjectStorage):
         if self.sftp_secret_type == 'password':
             self.ssh.connect(self.sftp_host, self.sftp_port, self.sftp_username, self.sftp_password)
         elif self.sftp_secret_type == 'ssh_key':
-            pkey = paramiko.RSAKey.from_private_key(io.StringIO(self.sftp_private_key))
-            self.ssh.connect(self.sftp_host, self.sftp_port, self.sftp_username, pkey=pkey,
-                             passphrase=self.sftp_passphrase)
+            private_key = self.sftp_private_key or ''
+            if '\\n' in private_key and '\n' not in private_key:
+                private_key = private_key.replace('\\n', '\n')
+            pkey = ssh_key_string_to_obj(private_key, password=self.sftp_passphrase or None)
+            self.ssh.connect(self.sftp_host, self.sftp_port, self.sftp_username, pkey=pkey)
         self.sftp = self.ssh.open_sftp()
 
     def confirm_connected(self):


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes SFTP replay storage connection test failure when using SSH key authentication.
Previously, SFTP storage parsed private keys only with `paramiko.RSAKey.from_private_key`, which could fail for non-RSA keys, encrypted private keys, or keys stored with escaped newline characters. This could cause errors such as: `Test failure: unpack requires a buffer of 4 bytes`

#### Summary of your change

Reused the `existing ssh_key_string_to_obj` utility to parse SSH private keys.
Passed STP_PASSPHRASE during private key parsing. 
Added compatibility for private keys stored with escaped newline characters.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.