### PR TITLE
fix: failure when changing network device passwords through a gateway

### DIFF
--- a/apps/accounts/automations/change_secret/custom/ssh/main.yml
+++ b/apps/accounts/automations/change_secret/custom/ssh/main.yml
@@ -41,6 +41,8 @@
         password: "{{ account.secret }}"
         commands: "{{ params.commands }}"
         answers: "{{ params.answers }}"
+        old_ssh_version: "{{ jms_asset.old_ssh_version | default(False) }}"
+        gateway_args: "{{ jms_asset.ansible_ssh_common_args | default(None) }}"
         recv_timeout: "{{ params.recv_timeout | default(30) }}"
         delay_time: "{{ params.delay_time | default(2) }}"
         prompt: "{{ params.prompt | default('.*') }}"


### PR DESCRIPTION
## What this PR does / why we need it?

Fixes an issue where changing network device passwords through a gateway may fail in v4.

The password change step uses `custom_command`, but it did not pass the gateway-related parameters to the module. As a result, when the asset requires a gateway connection, the password change command could not use the gateway tunnel correctly.

## Summary of your change

- Added `gateway_args` to the network device password change step.
- Added `old_ssh_version` to keep behavior consistent with the connection test and verification steps.
- Confirmed that the premature gateway tunnel cleanup fix from v3 is already covered by the current v4 `remote_client.py` implementation.

## Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follows the Conventional Commits specification.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.