### PR TITLE
feat(automation): add website script support for automation

### DIFF
--- a/apps/accounts/automations/change_secret/custom/web/main.yml
+++ b/apps/accounts/automations/change_secret/custom/web/main.yml
@@ -1,0 +1,43 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require change_secret script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website change_secret"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Run change secret script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_TARGET_ACCOUNT: "{{ account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: change_cmd
+      delegate_to: localhost
+      failed_when: change_cmd.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ change_cmd.rc | default(-1) }}"
+          stdout_lines: "{{ change_cmd.stdout_lines | default([]) }}"
+          stderr_lines: "{{ change_cmd.stderr_lines | default([]) }}"
+      when: change_cmd is defined

--- a/apps/accounts/automations/change_secret/custom/web/manifest.yml
+++ b/apps/accounts/automations/change_secret/custom/web/manifest.yml
@@ -1,0 +1,71 @@
+id: change_secret_website_script
+name: "{{ 'Website change secret (script)' | trans }}"
+category: web
+type:
+  - website
+method: change_secret
+protocol: http
+priority: 40
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Change secret script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website change secret (script):
+    zh: 'Website：改密（自定义脚本）'
+    en: 'Website: change secret (custom script)'
+    ja: 'Website: パスワード変更（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Change secret script path help:
+    zh: |
+      填写 JumpServer 本机脚本的绝对路径，须位于系统配置的允许目录内（CUSTOM_SCRIPT_ROOT）。
+      以自动化任务 Python 解释器执行：`python <路径>`（扩展名不限）；退出码 0 表示改密成功。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（特权账号）、JMS_TARGET_ACCOUNT（被改密账号 JSON，含新 secret）、JMS_PARAMS（本平台参数）。
+    en: |
+      Absolute path on the JumpServer host under CUSTOM_SCRIPT_ROOT.
+      Runs as automation_python <path> (any extension); exit code 0 means success.
+      Env: JMS_ASSET, JMS_ACCOUNT (privileged), JMS_TARGET_ACCOUNT (target JSON with new secret), JMS_PARAMS.
+    ja: |
+      JumpServer 上のスクリプト絶対パス（CUSTOM_SCRIPT_ROOT 配下）。
+      自動化用 Python で実行（拡張子任意）。終了コード 0 が成功。
+      環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_TARGET_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加传给脚本的命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+      实际命令：python <脚本路径> <参数1> …
+    en: |
+      Extra argv after the script path as a JSON array (default []).
+      Example: ['--insecure'] for self-signed TLS.
+      Effective command: python <script> <arg1> …
+    ja: |
+      スクリプトに渡す追加 argv（JSON 配列、既定 []）。
+      例: ['--insecure']。実行: python <script> <arg1> …
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/accounts/automations/gather_account/custom/web/main.yml
+++ b/apps/accounts/automations/gather_account/custom/web/main.yml
@@ -1,0 +1,50 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require gather script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website gather_accounts"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Run gather accounts script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: gather_cmd
+      delegate_to: localhost
+      failed_when: gather_cmd.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ gather_cmd.rc | default(-1) }}"
+          stdout_lines: "{{ gather_cmd.stdout_lines | default([]) }}"
+          stderr_lines: "{{ gather_cmd.stderr_lines | default([]) }}"
+      when: gather_cmd is defined
+
+    - name: Parse gather JSON from stdout
+      ansible.builtin.set_fact:
+        info: "{{ gather_cmd.stdout | trim | from_json }}"
+
+    # debug 任务勿设 name，否则回调键非 debug，manager 无法读取 result['debug']['res']['info']
+    - debug:
+        var: info

--- a/apps/accounts/automations/gather_account/custom/web/manifest.yml
+++ b/apps/accounts/automations/gather_account/custom/web/manifest.yml
@@ -1,0 +1,72 @@
+id: gather_accounts_website_script
+name: "{{ 'Website gather accounts (script)' | trans }}"
+category: web
+type:
+  - website
+method: gather_accounts
+priority: 40
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Gather accounts script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website gather accounts (script):
+    zh: 'Website：账号发现（自定义脚本）'
+    en: 'Website: gather accounts (custom script)'
+    ja: 'Website: アカウント収集（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Gather accounts script path help:
+    zh: |
+      填写 JumpServer 本机脚本的绝对路径，须位于系统配置的允许目录内（CUSTOM_SCRIPT_ROOT）。
+      以自动化任务 Python 解释器执行：python <路径>（扩展名不限）；退出码 0 表示执行成功。
+      标准输出须为单行 JSON 对象：键为用户名，值为该账号的可选字段对象（由 JumpServer 解析入库）。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（特权账号）、JMS_PARAMS（本平台参数）。
+    en: |
+      Absolute path on the JumpServer host under CUSTOM_SCRIPT_ROOT.
+      Runs as automation_python <path> (any extension); exit code 0 required.
+      Stdout must be one line of JSON: username -> optional account fields object.
+      Env: JMS_ASSET, JMS_ACCOUNT, JMS_PARAMS.
+    ja: |
+      JumpServer 上のスクリプト絶対パス（CUSTOM_SCRIPT_ROOT 配下）。
+      自動化用 Python で実行。終了コード 0。標準出力は 1 行 JSON（ユーザー名 -> フィールド）。
+      環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加传给脚本的命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+      实际命令：python <脚本路径> <参数1> …
+    en: |
+      Extra argv after the script path as a JSON array (default []).
+      Example: ['--insecure'] for self-signed TLS.
+      Effective command: python <script> <arg1> …
+    ja: |
+      スクリプトに渡す追加 argv（JSON 配列、既定 []）。
+      例: ['--insecure']。実行: python <script> <arg1> …
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/accounts/automations/gather_account/filter.py
+++ b/apps/accounts/automations/gather_account/filter.py
@@ -281,6 +281,31 @@ class GatherAccountsFilter:
                 result[username] = user
         return result
 
+    @staticmethod
+    def website_script_filter(info):
+        if not isinstance(info, dict):
+            return {}
+        result = {}
+        for username, user_info in info.items():
+            if not username:
+                continue
+            if not isinstance(user_info, dict):
+                user_info = {}
+            user = {
+                'username': username,
+                'date_password_change': parse_date(user_info.get('date_password_change')),
+                'date_password_expired': parse_date(user_info.get('date_password_expired')),
+                'date_last_login': parse_date(user_info.get('date_last_login')),
+                'groups': user_info.get('groups', '') or '',
+            }
+            detail = user_info.get('detail')
+            if detail is not None and not isinstance(detail, dict):
+                detail = {'value': detail}
+            if isinstance(detail, dict):
+                user['detail'] = detail
+            result[username] = user
+        return result
+
     def run(self, method_id_meta_mapper, info):
         run_method_name = None
         for k, v in method_id_meta_mapper.items():

--- a/apps/accounts/automations/push_account/custom/web/main.yml
+++ b/apps/accounts/automations/push_account/custom/web/main.yml
@@ -1,0 +1,43 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require push_account script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website push_account"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Run push account script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_TARGET_ACCOUNT: "{{ account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: push_cmd
+      delegate_to: localhost
+      failed_when: push_cmd.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ push_cmd.rc | default(-1) }}"
+          stdout_lines: "{{ push_cmd.stdout_lines | default([]) }}"
+          stderr_lines: "{{ push_cmd.stderr_lines | default([]) }}"
+      when: push_cmd is defined

--- a/apps/accounts/automations/push_account/custom/web/manifest.yml
+++ b/apps/accounts/automations/push_account/custom/web/manifest.yml
@@ -1,0 +1,71 @@
+id: push_account_website_script
+name: "{{ 'Website push account (script)' | trans }}"
+category: web
+type:
+  - website
+method: push_account
+protocol: http
+priority: 40
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Push account script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website push account (script):
+    zh: 'Website：推送账号（自定义脚本）'
+    en: 'Website: push account (custom script)'
+    ja: 'Website: アカウントプッシュ（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Push account script path help:
+    zh: |
+      填写 JumpServer 本机脚本的绝对路径，须位于系统配置的允许目录内（CUSTOM_SCRIPT_ROOT）。
+      以自动化任务 Python 解释器执行：python <路径>（扩展名不限）；退出码 0 表示推送成功。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（特权账号）、JMS_TARGET_ACCOUNT（待推送账号 JSON，含 secret）、JMS_PARAMS（本平台参数）。
+    en: |
+      Absolute path on the JumpServer host under CUSTOM_SCRIPT_ROOT.
+      Runs as automation_python <path> (any extension); exit code 0 means success.
+      Env: JMS_ASSET, JMS_ACCOUNT (privileged), JMS_TARGET_ACCOUNT (account JSON with secret), JMS_PARAMS.
+    ja: |
+      JumpServer 上のスクリプト絶対パス（CUSTOM_SCRIPT_ROOT 配下）。
+      自動化用 Python で実行。終了コード 0 が成功。
+      環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_TARGET_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加传给脚本的命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+      实际命令：python <脚本路径> <参数1> …
+    en: |
+      Extra argv after the script path as a JSON array (default []).
+      Example: ['--insecure'] for self-signed TLS.
+      Effective command: python <script> <arg1> …
+    ja: |
+      スクリプトに渡す追加 argv（JSON 配列、既定 []）。
+      例: ['--insecure']。実行: python <script> <arg1> …
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/accounts/automations/remove_account/custom/web/main.yml
+++ b/apps/accounts/automations/remove_account/custom/web/main.yml
@@ -1,0 +1,43 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require remove_account script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website remove_account"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Run remove account script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_TARGET_ACCOUNT: "{{ account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: remove_cmd
+      delegate_to: localhost
+      failed_when: remove_cmd.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ remove_cmd.rc | default(-1) }}"
+          stdout_lines: "{{ remove_cmd.stdout_lines | default([]) }}"
+          stderr_lines: "{{ remove_cmd.stderr_lines | default([]) }}"
+      when: remove_cmd is defined

--- a/apps/accounts/automations/remove_account/custom/web/manifest.yml
+++ b/apps/accounts/automations/remove_account/custom/web/manifest.yml
@@ -1,0 +1,71 @@
+id: remove_account_website_script
+name: "{{ 'Website remove account (script)' | trans }}"
+category: web
+type:
+  - website
+method: remove_account
+protocol: http
+priority: 40
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Remove account script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website remove account (script):
+    zh: 'Website：删除账号（自定义脚本）'
+    en: 'Website: remove account (custom script)'
+    ja: 'Website: アカウント削除（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Remove account script path help:
+    zh: |
+      填写 JumpServer 本机脚本的绝对路径，须位于系统配置的允许目录内（CUSTOM_SCRIPT_ROOT）。
+      以自动化任务 Python 解释器执行：python <路径>（扩展名不限）；退出码 0 表示删除成功。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（特权账号）、JMS_TARGET_ACCOUNT（待删除账号 JSON，通常含 username）、JMS_PARAMS（本平台参数）。
+    en: |
+      Absolute path on the JumpServer host under CUSTOM_SCRIPT_ROOT.
+      Runs as automation_python <path> (any extension); exit code 0 means success.
+      Env: JMS_ASSET, JMS_ACCOUNT (privileged), JMS_TARGET_ACCOUNT (account JSON, typically username), JMS_PARAMS.
+    ja: |
+      JumpServer 上のスクリプト絶対パス（CUSTOM_SCRIPT_ROOT 配下）。
+      自動化用 Python で実行。終了コード 0 が成功。
+      環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_TARGET_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加传给脚本的命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+      实际命令：python <脚本路径> <参数1> …
+    en: |
+      Extra argv after the script path as a JSON array (default []).
+      Example: ['--insecure'] for self-signed TLS.
+      Effective command: python <script> <arg1> …
+    ja: |
+      スクリプトに渡す追加 argv（JSON 配列、既定 []）。
+      例: ['--insecure']。実行: python <script> <arg1> …
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/accounts/automations/verify_account/custom/web/main.yml
+++ b/apps/accounts/automations/verify_account/custom/web/main.yml
@@ -1,0 +1,43 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require verify_account script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website verify_account"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Run verify account script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_TARGET_ACCOUNT: "{{ account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: verify_cmd
+      delegate_to: localhost
+      failed_when: verify_cmd.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ verify_cmd.rc | default(-1) }}"
+          stdout_lines: "{{ verify_cmd.stdout_lines | default([]) }}"
+          stderr_lines: "{{ verify_cmd.stderr_lines | default([]) }}"
+      when: verify_cmd is defined

--- a/apps/accounts/automations/verify_account/custom/web/manifest.yml
+++ b/apps/accounts/automations/verify_account/custom/web/manifest.yml
@@ -1,0 +1,71 @@
+id: verify_account_website_script
+name: "{{ 'Website verify account (script)' | trans }}"
+category: web
+type:
+  - website
+method: verify_account
+protocol: http
+priority: 40
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Verify account script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website verify account (script):
+    zh: 'Website：校验账号（自定义脚本）'
+    en: 'Website: verify account (custom script)'
+    ja: 'Website: アカウント検証（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Verify account script path help:
+    zh: |
+      填写 JumpServer 本机脚本的绝对路径，须位于系统配置的允许目录内（CUSTOM_SCRIPT_ROOT）。
+      以自动化任务 Python 解释器执行：python <路径>（扩展名不限）；退出码 0 表示校验通过。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（特权账号）、JMS_TARGET_ACCOUNT（待校验账号 JSON）、JMS_PARAMS（本平台参数）。
+    en: |
+      Absolute path on the JumpServer host under CUSTOM_SCRIPT_ROOT.
+      Runs as automation_python <path> (any extension); exit code 0 means verification passed.
+      Env: JMS_ASSET, JMS_ACCOUNT (privileged), JMS_TARGET_ACCOUNT (account JSON), JMS_PARAMS.
+    ja: |
+      JumpServer 上のスクリプト絶対パス（CUSTOM_SCRIPT_ROOT 配下）。
+      自動化用 Python で実行。終了コード 0 が検証成功。
+      環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_TARGET_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加传给脚本的命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+      实际命令：python <脚本路径> <参数1> …
+    en: |
+      Extra argv after the script path as a JSON array (default []).
+      Example: ['--insecure'] for self-signed TLS.
+      Effective command: python <script> <arg1> …
+    ja: |
+      スクリプトに渡す追加 argv（JSON 配列、既定 []）。
+      例: ['--insecure']。実行: python <script> <arg1> …
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/assets/automations/base/manager.py
+++ b/apps/assets/automations/base/manager.py
@@ -253,6 +253,12 @@ class PlaybookPrepareMixin:
         method_type = self.__class__.method_type()
         host = self.convert_cert_to_file(host, kwargs.get("path_dir"))
         host["params"] = self.get_params(automation, method_type)
+        if automation is not None:
+            method_attr = "{}_method".format(method_type)
+            method_id = getattr(automation, method_attr, None)
+            meta = self.method_id_meta_mapper.get(method_id) if method_id else None
+            if meta and meta.get("category") == "web":
+                host["custom_script_root"] = settings.CUSTOM_SCRIPT_ROOT
         return host
 
     @staticmethod

--- a/apps/assets/automations/gather_facts/custom/web/main.yml
+++ b/apps/assets/automations/gather_facts/custom/web/main.yml
@@ -1,0 +1,50 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require gather_facts script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website gather_facts"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Run gather facts script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: gather_facts_cmd
+      delegate_to: localhost
+      failed_when: gather_facts_cmd.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ gather_facts_cmd.rc | default(-1) }}"
+          stdout_lines: "{{ gather_facts_cmd.stdout_lines | default([]) }}"
+          stderr_lines: "{{ gather_facts_cmd.stderr_lines | default([]) }}"
+      when: gather_facts_cmd is defined
+
+    - name: Define info from script stdout
+      ansible.builtin.set_fact:
+        info: "{{ gather_facts_cmd.stdout | trim | from_json }}"
+
+    # debug 任务勿设 name，否则回调键非 debug，manager 无法读取 result['debug']['res']['info']
+    - debug:
+        var: info

--- a/apps/assets/automations/gather_facts/custom/web/manifest.yml
+++ b/apps/assets/automations/gather_facts/custom/web/manifest.yml
@@ -1,0 +1,73 @@
+id: gather_facts_website_script
+name: "{{ 'Website gather facts (script)' | trans }}"
+category: web
+type:
+  - website
+method: gather_facts
+protocol: http
+priority: 40
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Gather facts script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website gather facts (script):
+    zh: 'Website：收集资产信息（自定义脚本）'
+    en: 'Website: gather facts (custom script)'
+    ja: 'Website: ファクト収集（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Gather facts script path help:
+    zh: |
+      填写 JumpServer 本机脚本的绝对路径，须位于系统配置的允许目录内（CUSTOM_SCRIPT_ROOT）。
+      以自动化任务 Python 解释器执行：python <路径>（扩展名不限）；退出码 0 表示执行成功。
+      标准输出须为 JSON 对象，写入资产的 gathered_info 字段。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（特权账号）、JMS_PARAMS（本平台参数）。
+    en: |
+      Absolute path on the JumpServer host under CUSTOM_SCRIPT_ROOT.
+      Runs as automation_python <path> (any extension); exit code 0 required.
+      Stdout must be a JSON object stored as gathered_info on the asset.
+      Env: JMS_ASSET, JMS_ACCOUNT, JMS_PARAMS.
+    ja: |
+      JumpServer 上のスクリプト絶対パス（CUSTOM_SCRIPT_ROOT 配下）。
+      自動化用 Python で実行。終了コード 0。標準出力は gathered_info 用 JSON オブジェクト。
+      環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加传给脚本的命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+      实际命令：python <脚本路径> <参数1> …
+    en: |
+      Extra argv after the script path as a JSON array (default []).
+      Example: ['--insecure'] for self-signed TLS.
+      Effective command: python <script> <arg1> …
+    ja: |
+      スクリプトに渡す追加 argv（JSON 配列、既定 []）。
+      例: ['--insecure']。実行: python <script> <arg1> …
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/assets/automations/ping/custom/web/http/main.yml
+++ b/apps/assets/automations/ping/custom/web/http/main.yml
@@ -1,0 +1,19 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Website connectivity via HTTP
+      ansible.builtin.uri:
+        url: "{{ jms_asset.address }}"
+        method: "{{ params.http_method | default('HEAD') }}"
+        timeout: "{{ params.timeout_seconds | default(10) | int }}"
+        validate_certs: "{{ params.validate_certs | default(true) | bool }}"
+        follow_redirects: true
+        status_code: [200, 201, 204, 301, 302, 303, 307, 308, 401, 403, 405]
+      register: uri_check
+      delegate_to: localhost
+      failed_when: uri_check.status is defined and uri_check.status >= 400

--- a/apps/assets/automations/ping/custom/web/http/manifest.yml
+++ b/apps/assets/automations/ping/custom/web/http/manifest.yml
@@ -1,0 +1,54 @@
+id: ping_website_http
+name: "{{ 'Website ping HTTP' | trans }}"
+category: web
+type:
+  - website
+method: ping
+protocol: http
+priority: 40
+params:
+  - name: http_method
+    type: str
+    label: "{{ 'HTTP method' | trans }}"
+    default: HEAD
+    help_text: "{{ 'Website ping HTTP method help' | trans }}"
+  - name: timeout_seconds
+    type: int
+    label: "{{ 'Timeout (seconds)' | trans }}"
+    default: 10
+    help_text: "{{ 'Website ping HTTP timeout help' | trans }}"
+  - name: validate_certs
+    type: bool
+    label: "{{ 'Validate HTTPS certificates' | trans }}"
+    default: true
+    help_text: "{{ 'Validate HTTPS certificates help' | trans }}"
+
+i18n:
+  Website ping HTTP:
+    zh: 'Website：连通性探测（HTTP）'
+    en: 'Website: connectivity check (HTTP)'
+    ja: 'Website: 疎通確認（HTTP）'
+  HTTP method:
+    zh: HTTP 请求方法
+    en: HTTP request method
+    ja: HTTP メソッド
+  Website ping HTTP method help:
+    zh: 对资产地址（如 Grafana 登录页 URL）发起 HTTP 请求，常用 HEAD 或 GET。
+    en: HTTP request to the asset address (e.g. Grafana login URL), typically HEAD or GET.
+    ja: 資産 URL へ HTTP リクエスト（HEAD / GET など）。
+  Timeout (seconds):
+    zh: 超时时间（秒）
+    en: Timeout (seconds)
+    ja: タイムアウト（秒）
+  Website ping HTTP timeout help:
+    zh: HTTP 请求最大等待时间（秒）。默认 10。
+    en: Maximum wait for the HTTP request (seconds). Default 10.
+    ja: HTTP リクエストの最大待ち時間（秒）。既定 10。
+  Validate HTTPS certificates:
+    zh: 校验 HTTPS 证书
+    en: Validate HTTPS certificates
+    ja: HTTPS 証明書を検証
+  Validate HTTPS certificates help:
+    zh: 使用 HTTPS 时是否校验服务端证书链；自签证书可关闭。
+    en: Whether to verify the server certificate chain for HTTPS.
+    ja: HTTPS 時にサーバー証明書を検証するか。

--- a/apps/assets/automations/ping/custom/web/script/main.yml
+++ b/apps/assets/automations/ping/custom/web/script/main.yml
@@ -1,0 +1,42 @@
+- hosts: all
+  gather_facts: no
+  vars:
+    ansible_connection: local
+    ansible_become: false
+    ansible_python_interpreter: "{{ local_python_interpreter }}"
+
+  tasks:
+    - name: Require ping script_path
+      ansible.builtin.assert:
+        that:
+          - params.script_path is defined
+          - params.script_path | length > 0
+        fail_msg: "script_path is required for website ping (custom script)"
+
+    - name: Validate custom script path
+      validate_custom_script_path:
+        path: "{{ params.script_path | default('', true) }}"
+        allowed_root: "{{ custom_script_root }}"
+      register: website_script_path
+      delegate_to: localhost
+
+    - name: Website connectivity via custom script
+      ansible.builtin.command:
+        argv: "{{ [ansible_python_interpreter, website_script_path.resolved_path] + (params.script_args_json | default('[]', true) | from_json) }}"
+      environment:
+        JMS_ASSET: "{{ jms_asset | to_json }}"
+        JMS_ACCOUNT: "{{ jms_account | to_json }}"
+        JMS_PARAMS: "{{ params | to_json }}"
+      async: "{{ params.recv_timeout | default(120) | int }}"
+      poll: 1
+      register: script_ping
+      delegate_to: localhost
+      failed_when: script_ping.rc | default(1) != 0
+
+    - name: Log custom website script diagnostics
+      ansible.builtin.debug:
+        msg:
+          rc: "{{ script_ping.rc | default(-1) }}"
+          stdout_lines: "{{ script_ping.stdout_lines | default([]) }}"
+          stderr_lines: "{{ script_ping.stderr_lines | default([]) }}"
+      when: script_ping is defined

--- a/apps/assets/automations/ping/custom/web/script/manifest.yml
+++ b/apps/assets/automations/ping/custom/web/script/manifest.yml
@@ -1,0 +1,67 @@
+id: ping_website_script
+name: "{{ 'Website ping script' | trans }}"
+category: web
+type:
+  - website
+method: ping
+protocol: http
+priority: 41
+params:
+  - name: script_path
+    type: str
+    label: "{{ 'Script path' | trans }}"
+    default: ''
+    help_text: "{{ 'Website ping script path help' | trans }}"
+  - name: script_args_json
+    type: text
+    label: "{{ 'Script arguments' | trans }}"
+    default: '[]'
+    help_text: "{{ 'Script arguments help' | trans }}"
+  - name: recv_timeout
+    type: int
+    label: "{{ 'Script timeout' | trans }}"
+    default: 120
+    help_text: "{{ 'Script timeout help' | trans }}"
+
+i18n:
+  Website ping script:
+    zh: 'Website：连通性探测（自定义脚本）'
+    en: 'Website: connectivity check (custom script)'
+    ja: 'Website: 疎通確認（カスタムスクリプト）'
+  Script path:
+    zh: 自定义脚本路径
+    en: Custom script path
+    ja: カスタムスクリプトパス
+  Website ping script path help:
+    zh: |
+      在 JumpServer 本机执行脚本探测连通性，须位于 CUSTOM_SCRIPT_ROOT 目录内；退出码 0 表示可达。
+      例如 Grafana 可使用 grafana_ping.py（GET /api/health）。
+      环境变量：JMS_ASSET（资产）、JMS_ACCOUNT（账号，可选）、JMS_PARAMS（本平台参数）。
+    en: |
+      Run a script on the JumpServer host under CUSTOM_SCRIPT_ROOT; exit code 0 means reachable.
+      Example for Grafana: grafana_ping.py (GET /api/health).
+      Env: JMS_ASSET, JMS_ACCOUNT (optional), JMS_PARAMS.
+    ja: |
+      JumpServer 上でスクリプト実行（CUSTOM_SCRIPT_ROOT 配下）。終了コード 0 が成功。
+      例: grafana_ping.py。環境変数: JMS_ASSET, JMS_ACCOUNT, JMS_PARAMS.
+  Script arguments:
+    zh: 脚本参数（JSON 数组）
+    en: Script arguments (JSON array)
+    ja: スクリプト引数（JSON 配列）
+  Script arguments help:
+    zh: |
+      追加命令行参数，JSON 数组字符串，默认 []。
+      例如自签证书场景可填 ['--insecure']。
+    en: |
+      Extra argv as a JSON array (default []).
+      Example for self-signed TLS: ['--insecure'].
+    ja: |
+      追加 argv（JSON 配列、既定 []）。例: ['--insecure']。
+  Script timeout:
+    zh: 执行超时（秒）
+    en: Execution timeout (seconds)
+    ja: 実行タイムアウト（秒）
+  Script timeout help:
+    zh: 脚本子进程的最大执行时间（秒），超时则任务失败。默认 120。
+    en: Maximum script runtime in seconds; task fails on timeout. Default 120.
+    ja: スクリプトの最大実行時間（秒）。既定 120。

--- a/apps/assets/const/web.py
+++ b/apps/assets/const/web.py
@@ -18,18 +18,29 @@ class WebTypes(BaseType):
 
     @classmethod
     def _get_automation_constrains(cls) -> dict:
-        constrains = {
-            '*': {
-                'ansible_enabled': False,
-                'ping_enabled': False,
-                'gather_facts_enabled': False,
-                'verify_account_enabled': False,
-                'change_secret_enabled': False,
-                'push_account_enabled': False,
-                'gather_accounts_enabled': False,
-            }
+        disabled = {
+            'ansible_enabled': False,
+            'ping_enabled': False,
+            'gather_facts_enabled': False,
+            'verify_account_enabled': False,
+            'change_secret_enabled': False,
+            'push_account_enabled': False,
+            'gather_accounts_enabled': False,
+            'remove_account_enabled': False,
         }
-        return constrains
+        return {
+            '*': disabled,
+            cls.WEBSITE: {
+                'ansible_enabled': True,
+                'ping_enabled': True,
+                'gather_facts_enabled': True,
+                'verify_account_enabled': True,
+                'change_secret_enabled': True,
+                'push_account_enabled': True,
+                'gather_accounts_enabled': True,
+                'remove_account_enabled': True,
+            },
+        }
 
     @classmethod
     def _get_protocol_constrains(cls) -> dict:

--- a/apps/jumpserver/conf.py
+++ b/apps/jumpserver/conf.py
@@ -188,6 +188,8 @@ class Config(dict):
         'DEBUG': False,
         'DEBUG_DEV': False,
         'DEBUG_ANSIBLE': False,
+        # Allowed directory for custom automation scripts (Website, etc.); empty uses PROJECT_DIR/data/automations
+        'CUSTOM_SCRIPT_ROOT': '',
         'LOG_LEVEL': 'DEBUG',
         'LOG_DIR': os.path.join(PROJECT_DIR, 'data', 'logs'),
         'DB_ENGINE': 'mysql',

--- a/apps/jumpserver/settings/base.py
+++ b/apps/jumpserver/settings/base.py
@@ -49,6 +49,9 @@ DEBUG = CONFIG.DEBUG
 DEBUG_DEV = CONFIG.DEBUG_DEV
 # SECURITY WARNING: If you run ansible task with debug turned on, more debug msg with be log
 DEBUG_ANSIBLE = CONFIG.DEBUG_ANSIBLE
+CUSTOM_SCRIPT_ROOT = CONFIG.CUSTOM_SCRIPT_ROOT or os.path.join(
+    PROJECT_DIR, 'data', 'automations'
+)
 
 # Absolute url for some case, for example email link
 SITE_URL = CONFIG.SITE_URL

--- a/apps/libs/ansible/modules/validate_custom_script_path.py
+++ b/apps/libs/ansible/modules/validate_custom_script_path.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: validate_custom_script_path
+short_description: Validate custom automation script path under allowed root
+description:
+  - Resolves C(path) with C(os.path.realpath), requires a regular readable file, and checks that it
+    lies under the allowed directory prefix (also resolved).
+  - Intended for local execution of interpreter-driven scripts (e.g. C(python <path> ...)); does not
+    require a C(.py) suffix.
+  - Returns C(resolved_path) only; the playbook should build C(argv) (e.g. interpreter + path + extras).
+options:
+  path:
+    description: Absolute path to the script file (symlinks resolved).
+    type: str
+    required: true
+  allowed_root:
+    description: Allowed directory prefix for the script, typically from JumpServer C(CUSTOM_SCRIPT_ROOT).
+    type: str
+    required: true
+"""
+
+EXAMPLES = r"""
+- name: Validate custom script path
+  validate_custom_script_path:
+    path: "{{ params.script_path }}"
+    allowed_root: "{{ custom_script_root }}"
+  register: website_script_path
+"""
+
+RETURN = r"""
+resolved_path:
+  description: Canonical script path after symlink resolution.
+  returned: success
+  type: str
+"""
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def _resolve_root(raw_root):
+    root = (raw_root or "").strip()
+    if not root:
+        raise ValueError("allowed_root must be a non-empty string")
+    return os.path.realpath(os.path.expanduser(root))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type="str", required=True),
+            allowed_root=dict(type="str", required=True),
+        ),
+        supports_check_mode=True,
+    )
+    raw_path = module.params["path"] or ""
+    path = raw_path.strip()
+    if not path:
+        module.fail_json(msg="path must be a non-empty string")
+
+    try:
+        root = _resolve_root(module.params["allowed_root"])
+    except ValueError as exc:
+        module.fail_json(msg=str(exc))
+
+    try:
+        resolved = os.path.realpath(os.path.expanduser(path))
+    except Exception as exc:
+        module.fail_json(msg="cannot resolve path: %s" % (exc,))
+
+    if not os.path.isfile(resolved):
+        module.fail_json(
+            msg="path is not a regular file (after symlink resolution): %s" % (resolved,),
+        )
+
+    if not os.access(resolved, os.R_OK):
+        module.fail_json(msg="script is not readable: %s" % (resolved,))
+
+    if resolved != root and not resolved.startswith(root + os.sep):
+        module.fail_json(
+            msg="path %s is not under allowed root %s" % (resolved, root),
+        )
+
+    module.exit_json(changed=False, resolved_path=resolved)
+
+
+if __name__ == "__main__":
+    main()

--- a/config_example.yml
+++ b/config_example.yml
@@ -100,3 +100,7 @@ REDIS_PORT: 6379
 #FACE_RECOGNITION_ENABLED: true
 #FACE_RECOGNITION_DISTANCE_THRESHOLD': 0.35
 #FACE_RECOGNITION_COSINE_THRESHOLD': 0.95
+
+# Allowed directory for custom automation scripts (Website category, etc.)
+# Default: <PROJECT_DIR>/data/automations
+# CUSTOM_SCRIPT_ROOT: /opt/jumpserver/data/automations


### PR DESCRIPTION
#### What this PR does / why we need it?

Introduced new Ansible playbooks and manifests for change_secret, gather_accounts, and verify_account automation methods. Each script requires a defined script path and supports passing arguments as JSON. Enhanced the web automation framework to facilitate custom script execution and improved error handling for script execution failures.

#### Summary of your change

- 启用 Website 平台相关自动化能力
- Website 平台支持用自定义脚本做账号/资产自动化（改密、发现、推送、删除、校验、采集等）
- Web 资产 Ping 支持 HTTP 探测 和 脚本探测 两种方式
- 新增脚本路径校验模块与 CUSTOM_SCRIPT_ROOT 配置

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

#### 测试/使用方式

1. 创建 Web 平台，启用并配置需要的自动化任务
<img width="2503" height="1285" alt="image" src="https://github.com/user-attachments/assets/17b16903-8fcf-4ef2-b2ec-ac9b49eee093" />

2. 在对应目录增加相应的自动化任务脚本。如果最终容器化部署，默认路径为 `/data/jumpserver/core/data/automations/脚本名称.py`。目前只支持 Python 脚本。
3. 以 Grafana 资产账号改密脚本为例的脚本示例。
```python
#!/usr/bin/env python3
"""
Grafana 改密脚本：兼容 JumpServer「Website：改密（自定义脚本）」任务。

环境变量（与 apps/accounts/automations/change_secret/custom/web/main.yml 一致）：
  JMS_ASSET、JMS_ACCOUNT（特权账号）、JMS_TARGET_ACCOUNT（被改密账号，secret 为新密码）、JMS_PARAMS
  以上值为字符串时优先 ast.literal_eval，失败再 json.loads。

改密策略
--------
1) 自改密（官方 User API Change Password）
   PUT /api/user/password
   文档: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/#change-password

   需在 JMS_PARAMS 中提供当前密码，例如 old_secret 或 old_password（与 Basic 认证一致，并写入 JSON body）。

2) 管理员重置（JumpServer 默认：inventory 里仅有「新密码」，无旧密码）
   GET /api/users/lookup?loginOrEmail=…（Basic：JMS_ACCOUNT）
   PUT /api/admin/users/:id/password  {"password": "<新密码>"}
   需 JMS_ACCOUNT 为 Grafana 服务器管理员；说明见 Admin HTTP API 文档。

自签证书：Script argv JSON 填写 ["--insecure"] 或 JMS_PARAMS 中 tls_insecure / insecure 为真。
"""

from __future__ import annotations

import argparse
import ast
import json
import os
import sys
from typing import Any, Dict, Optional

import requests
from requests.auth import HTTPBasicAuth


def _load_dict_env(name: str) -> Dict[str, Any]:
    raw = os.environ.get(name)
    if not raw:
        return {}
    text = raw.strip()
    if not text:
        return {}
    val: Any
    try:
        val = ast.literal_eval(text)
    except (ValueError, SyntaxError):
        try:
            val = json.loads(text)
        except json.JSONDecodeError as e:
            raise RuntimeError(
                f"环境变量 {name} 无法解析为 dict（literal_eval 与 json.loads 均失败）: {e}"
            ) from e
    return val if isinstance(val, dict) else {}


def _strip_trailing_login_path(url_or_host: str) -> str:
    s = url_or_host.rstrip("/")
    low = s.lower()
    suffix = "/login"
    if low.endswith(suffix):
        s = s[: len(s) - len(suffix)].rstrip("/")
    return s


def _asset_base_url(asset: Dict[str, Any]) -> str:
    address = _strip_trailing_login_path((asset.get("address") or "").strip())
    port = asset.get("port")
    if not address:
        raise RuntimeError("JMS_ASSET.address 为空，无法拼接 Grafana 根 URL")

    low = address.lower()
    if low.startswith("http://") or low.startswith("https://"):
        return address.rstrip("/")

    host = address
    if port and ":" not in host.split("/")[0]:
        host = f"{host}:{port}"
    return f"https://{host}".rstrip("/")


def _normalize_secret(secret: Any) -> str:
    if secret is None:
        return ""
    if isinstance(secret, str):
        return secret.strip()
    return str(secret)


def _session_insecure_flags(params: Dict[str, Any]) -> bool:
    argv_insecure = any(a in ("--insecure", "-k") for a in sys.argv[1:])
    return argv_insecure or bool(
        params.get("tls_insecure") or params.get("insecure") or params.get("grafana_tls_insecure")
    )


def change_password_self(
    session: requests.Session,
    base: str,
    login: str,
    old_password: str,
    new_password: str,
    timeout: float,
) -> None:
    """PUT /api/user/password — 认证用户与待改密用户须一致。"""
    session.auth = HTTPBasicAuth(login, old_password)
    body = {
        "oldPassword": old_password,
        "newPassword": new_password,
        "confirmNew": new_password,
    }
    r = session.put(
        f"{base}/api/user/password",
        json=body,
        timeout=timeout,
    )
    r.raise_for_status()


def change_password_admin(
    session: requests.Session,
    base: str,
    admin_user: str,
    admin_password: str,
    target_login: str,
    new_password: str,
    timeout: float,
) -> None:
    session.auth = HTTPBasicAuth(admin_user, admin_password)
    r = session.get(
        f"{base}/api/users/lookup",
        params={"loginOrEmail": target_login},
        timeout=timeout,
    )
    r.raise_for_status()
    data = r.json()
    if not isinstance(data, dict) or "id" not in data:
        raise RuntimeError(f"用户 lookup 响应异常: {data!r}")
    uid = data["id"]
    r2 = session.put(
        f"{base}/api/admin/users/{uid}/password",
        json={"password": new_password},
        timeout=timeout,
    )
    r2.raise_for_status()


def run_jms() -> int:
    asset = _load_dict_env("JMS_ASSET")
    jms_account = _load_dict_env("JMS_ACCOUNT")
    target = _load_dict_env("JMS_TARGET_ACCOUNT")
    params = _load_dict_env("JMS_PARAMS")

    if not asset:
        raise RuntimeError("缺少 JMS_ASSET")
    if not target:
        raise RuntimeError("缺少 JMS_TARGET_ACCOUNT")

    base = _asset_base_url(asset)
    timeout = float(params.get("http_timeout", params.get("timeout", 30)))

    target_login = (target.get("username") or "").strip()
    new_password = _normalize_secret(target.get("secret"))
    if not target_login:
        raise RuntimeError("JMS_TARGET_ACCOUNT.username 为空")
    if not new_password:
        raise RuntimeError("JMS_TARGET_ACCOUNT.secret 为空（新密码）")

    old_secret = _normalize_secret(
        params.get("old_secret")
        or params.get("old_password")
        or params.get("grafana_old_password")
    )
    force_self = bool(params.get("grafana_use_self_password_api") or params.get("use_self_password_api"))
    force_admin = bool(params.get("grafana_use_admin_password_api") or params.get("use_admin_password_api"))

    if force_admin:
        use_self = False
    elif force_self:
        use_self = True
    else:
        use_self = bool(old_secret)

    session = requests.Session()
    session.headers.update(
        {
            "Accept": "application/json",
            "Content-Type": "application/json",
        }
    )
    session.verify = not _session_insecure_flags(params)

    if use_self:
        if not old_secret:
            raise RuntimeError(
                "自改密模式需要在 JMS_PARAMS 中提供 old_secret（或 old_password），"
                "或省略后由 Grafana 服务器管理员（JMS_ACCOUNT）走管理员重置接口。"
            )
        change_password_self(session, base, target_login, old_secret, new_password, timeout)
    else:
        admin_user = (jms_account.get("username") or "").strip()
        admin_pass = _normalize_secret(jms_account.get("secret"))
        if not admin_user or not admin_pass:
            raise RuntimeError("管理员重置需要完整的 JMS_ACCOUNT（username + secret）")
        change_password_admin(
            session, base, admin_user, admin_pass, target_login, new_password, timeout
        )

    return 0


def run_cli(args: argparse.Namespace) -> int:
    base = args.url.rstrip("/")
    session = requests.Session()
    session.headers.update(
        {
            "Accept": "application/json",
            "Content-Type": "application/json",
        }
    )
    session.verify = not args.insecure
    timeout = args.timeout

    if args.old_password:
        change_password_self(
            session,
            base,
            args.target_user,
            args.old_password,
            args.new_password,
            timeout,
        )
    else:
        if not args.admin_user or not args.admin_password:
            raise RuntimeError("未提供 --old-password 时，须同时提供 --admin-user 与 --admin-password 以走管理员重置")
        change_password_admin(
            session,
            base,
            args.admin_user,
            args.admin_password,
            args.target_user,
            args.new_password,
            timeout,
        )
    return 0


def main() -> int:
    jms_mode = bool(os.environ.get("JMS_ASSET", "").strip()) and not (
        "-h" in sys.argv or "--help" in sys.argv
    )
    if jms_mode:
        try:
            return run_jms()
        except (RuntimeError, requests.HTTPError, requests.RequestException) as e:
            print(str(e), file=sys.stderr)
            if isinstance(e, requests.HTTPError) and e.response is not None:
                print(e.response.text[:2000], file=sys.stderr)
            return 1

    parser = argparse.ArgumentParser(description="Grafana 改密（本地调试）")
    parser.add_argument("--url", default=os.environ.get("GRAFANA_URL", "http://127.0.0.1:3000"))
    parser.add_argument("--target-user", required=True, help="Grafana login")
    parser.add_argument("--new-password", required=True)
    parser.add_argument(
        "--old-password",
        default="",
        help="当前密码；若省略则使用管理员接口重置（需 --admin-user / --admin-password）",
    )
    parser.add_argument("--admin-user", default=os.environ.get("GRAFANA_ADMIN_USER", ""))
    parser.add_argument("--admin-password", default=os.environ.get("GRAFANA_ADMIN_PASSWORD", ""))
    parser.add_argument("--timeout", type=float, default=30.0)
    parser.add_argument("--insecure", action="store_true")
    args = parser.parse_args()
    try:
        return run_cli(args)
    except (RuntimeError, requests.HTTPError, requests.RequestException) as e:
        print(str(e), file=sys.stderr)
        if isinstance(e, requests.HTTPError) and e.response is not None:
            print(e.response.text[:2000], file=sys.stderr)
        return 1


if __name__ == "__main__":
    raise SystemExit(main())
```
4. 使用自定义的 Web 平台创建资产，并进行相应任务的测试。
<img width="2503" height="1285" alt="image" src="https://github.com/user-attachments/assets/eb3773ff-8bac-4bfb-b70c-df0426fe1bdc" />
