### PR TITLE
fix: site message session share link protocol issue

### DIFF
--- a/apps/terminal/models/session/sharing.py
+++ b/apps/terminal/models/session/sharing.py
@@ -9,7 +9,7 @@ from common.db.models import JMSBaseModel
 from common.utils import is_uuid
 from orgs.mixins.models import OrgModelMixin
 from orgs.utils import tmp_to_root_org
-from terminal.const import LoginFrom
+from terminal.const import LoginFrom, TerminalType
 from users.models import User
 
 __all__ = ['SessionSharing', 'SessionJoinRecord']
@@ -47,9 +47,18 @@ class SessionSharing(JMSBaseModel, OrgModelMixin):
     def __str__(self):
         return 'Creator: {}'.format(self.creator)
 
+    @property
+    def share_component(self) -> str:
+        terminal = self.session.terminal
+        if terminal:
+            return terminal.type
+        if self.session.protocol in ('vnc', 'rdp'):
+            return TerminalType.lion
+        return TerminalType.koko
+
     @cached_property
     def url(self) -> str:
-        return '%s/koko/share/%s/' % (self.origin, self.id)
+        return '%s/%s/share/%s/' % (self.origin, self.share_component, self.id)
 
     @cached_property
     def users_display(self) -> list:


### PR DESCRIPTION
What this PR does / why we need it?
VNC / RDP 等图形化会话分享时，站内信中的分享链接被硬编码为 /koko/share/ 路径。但 VNC、RDP 的 Web GUI 会话实际由 Lion 组件承载，而非 KoKo。接收者点击站内信链接后会因路由到错误组件而出现 WebSocket 已关闭 的错误。

本 PR 修复分享链接的生成逻辑，根据会话实际使用的终端组件（lion、koko 等）动态生成正确的分享 URL。

Summary of your change
在 SessionSharing 上新增 share_component 属性，用于解析正确的终端组件：
优先使用 session.terminal.type
若 terminal 为空，则对 vnc/rdp 协议兜底为 lion，其余协议兜底为 koko
修改 SessionSharing.url，动态拼接路径：{origin}/{component}/share/{id}/
VNC/RDP 会话分享的站内信链接由 /koko/share/.../ 修正为 /lion/share/.../
变更文件： apps/terminal/models/session/sharing.py

Please indicate you've done the following:

 Made sure tests are passing and test coverage is added if needed.

 Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).

 Considered the docs impact and opened a new docs issue or PR with docs changes if needed.