### PR TITLE
refactor: streamline key handling in EBCCipher and SM4Mixin

### DIFF
--- a/apps/common/sdk/gm/base/cipher.py
+++ b/apps/common/sdk/gm/base/cipher.py
@@ -22,21 +22,17 @@ class EBCCipher:
 
     def __init__(self, session, key_val):
         self._session = session
-        self._key = self.__get_key(key_val)
+        self._key = key_val if isinstance(key_val, bytes) else bytes(key_val, encoding='utf-8')
         self._alg = "sm4_ebc"
         self._iv = None
 
-    def __get_key(self, key_val):
-        key_val = self.__padding(key_val)
-        return self._session.import_key(key_val)
-
     @staticmethod
-    def __padding(val):
-        # padding
-        val = bytes(val)
-        while len(val) == 0 or len(val) % 16 != 0:
-            val += b'\0'
-        return val
+    def __padding(data):
+        if not isinstance(data, bytes):
+            data = bytes(data, encoding='utf-8')
+        while len(data) == 0 or len(data) % 16 != 0:
+            data += b'\0'
+        return data
 
     def encrypt(self, plain_text):
         plain_text = self.__padding(plain_text)
@@ -48,8 +44,13 @@ class EBCCipher:
         return bytes(plain_text)
 
     def destroy(self):
-        self._session.destroy_cipher_key(self._key)
         self._session.close()
+
+    def __del__(self):
+        try:
+            self.destroy()
+        except Exception:
+            pass
 
 
 class CBCCipher(EBCCipher):

--- a/apps/common/sdk/gm/base/device.py
+++ b/apps/common/sdk/gm/base/device.py
@@ -14,7 +14,6 @@ class Device:
         self.__load_driver(driver_path)
         # open device
         self.__open_device()
-        self.reset_key_store()
 
     def close(self):
         if self.__device is None:
@@ -68,6 +67,3 @@ class Device:
         if ret != 0:
             raise Exception("open {} device failed".format(self.name), ret)
         self.__device = device
-
-    def reset_key_store(self):
-        pass

--- a/apps/common/sdk/gm/base/session_mixin.py
+++ b/apps/common/sdk/gm/base/session_mixin.py
@@ -88,21 +88,6 @@ class SM3Mixin(BaseMixin):
 
 class SM4Mixin(BaseMixin):
 
-    def import_key(self, key_val):
-        # to c lang
-        key_val = (c_ubyte * len(key_val))(*key_val)
-
-        key = c_void_p()
-        ret = self._driver.SDF_ImportKey(self._session, key_val, c_int(len(key_val)), pointer(key))
-        if ret != 0:
-            raise GMDeviceError("import key failed", ret)
-        return key
-
-    def destroy_cipher_key(self, key):
-        ret = self._driver.SDF_DestroyKey(self._session, key)
-        if ret != 0:
-            raise Exception("destroy key failed")
-
     def encrypt(self, plain_text, key, alg, iv=None):
         return self.__do_cipher_action(plain_text, key, alg, iv, True)
 
@@ -110,20 +95,35 @@ class SM4Mixin(BaseMixin):
         return self.__do_cipher_action(cipher_text, key, alg, iv, False)
 
     def __do_cipher_action(self, text, key, alg, iv=None, encrypt=True):
-        text = (c_ubyte * len(text))(*text)
+        text_buf = (c_ubyte * len(text))(*text)
+        key_buf = (c_ubyte * len(key))(*key)
+
+        iv_buf = None
+        iv_len = 0
         if iv is not None:
-            iv = (c_ubyte * len(iv))(*iv)
+            iv_buf = (c_ubyte * len(iv))(*iv)
+            iv_len = len(iv)
 
         temp_data = (c_ubyte * len(text))()
         temp_data_length = c_int()
         if encrypt:
-            ret = self._driver.SDF_Encrypt(self._session, key, c_int(alg), iv, text, c_int(len(text)), temp_data,
-                                           pointer(temp_data_length))
+            ret = self._driver.SPII_EncryptEx(
+                self._session, text_buf, c_int(len(text)),
+                key_buf, c_int(len(key)),
+                iv_buf, c_int(iv_len),
+                c_int(alg),
+                temp_data, pointer(temp_data_length),
+            )
             if ret != 0:
                 raise GMDeviceError("encrypt failed", ret)
         else:
-            ret = self._driver.SDF_Decrypt(self._session, key, c_int(alg), iv, text, c_int(len(text)), temp_data,
-                                           pointer(temp_data_length))
+            ret = self._driver.SPII_DecryptEx(
+                self._session, text_buf, c_int(len(text)),
+                key_buf, c_int(len(key)),
+                iv_buf, c_int(iv_len),
+                c_int(alg),
+                temp_data, pointer(temp_data_length),
+            )
             if ret != 0:
                 raise GMDeviceError("decrypt failed", ret)
         return temp_data[:temp_data_length.value]

--- a/apps/common/sdk/gm/ccupm/device.py
+++ b/apps/common/sdk/gm/ccupm/device.py
@@ -9,6 +9,3 @@ class CCUPMDevice(Device):
 
     def open(self, driver_path="libsdf_crypto.so"):
         super().open(driver_path)
-
-    def reset_key_store(self):
-        pass

--- a/apps/common/sdk/gm/piico/device.py
+++ b/apps/common/sdk/gm/piico/device.py
@@ -1,7 +1,4 @@
-import os
 from ..base.device import Device
-from django.core.cache import cache
-from redis_lock import Lock as RedisLock
 
 
 class PiicoDevice(Device):
@@ -13,30 +10,3 @@ class PiicoDevice(Device):
     # 默认去lib路径检索
     def open(self, driver_path="libpiico_ccmu.so"):
         super().open(driver_path)
-
-    def reset_key_store(self):
-        redis_client = cache.client.get_client()
-        server_hostname = os.environ.get("SERVER_HOSTNAME")
-        RESET_LOCK_KEY = f"spiico:{server_hostname}:reset"
-        LOCK_EXPIRE_SECONDS = 300
-
-        if self._driver is None:
-            raise Exception("no driver loaded", 0)
-        if self.__device is None:
-            raise Exception("device not open", 0)
-
-        # ---- 分布式锁（Redis-Lock 实现 Redlock） ----
-        lock = RedisLock(
-            redis_client,
-            RESET_LOCK_KEY,
-            expire=LOCK_EXPIRE_SECONDS,  # 锁自动过期
-            auto_renewal=False,  # 不自动续租
-        )
-
-        # 尝试获取锁，拿不到直接返回
-        if not lock.acquire(blocking=False):
-            return
-            # ---- 真正执行 reset ----
-        ret = self._driver.SPII_ResetModule(self.__device)
-        if ret != 0:
-            raise Exception("reset device failed", ret)


### PR DESCRIPTION
## Summary
piico SM4 加解密改为三未信安专有的外部明文密钥模式，对齐 jumpserver-east 681ec88。

- SM4Mixin 改用 `SPII_EncryptEx/SPII_DecryptEx` 直传外部明文密钥，移除 `import_key/destroy_cipher_key` 密钥句柄逻辑
- EBCCipher 直接持有明文 key bytes，`destroy()` 只关 session，新增 `__del__` 兜底释放
- 移除 piico `reset_key_store`（Redis 分布式锁 + `SPII_ResetModule`）及 `open()` 中的调用
- ccupm 移除空的 `reset_key_store` 覆盖

## Tested
- 语法检查与模块导入链验证通过
- 实机 .so 调用未验证（无设备环境）

## Note
`SPII_*` 为 piico 专有接口，base 改动后 ccupm（libsdf_crypto.so）也会走该符号，需确认 ccupm 驱动是否导出。