### PR TITLE
fix:face_capature_create_token

### DIFF
--- a/apps/authentication/templates/authentication/face_capture.html
+++ b/apps/authentication/templates/authentication/face_capture.html
@@ -39,7 +39,11 @@
             let token;
 
             function createFaceCaptureToken() {
-                const csrf = getCookie('jms_csrftoken');
+                let prefix = getCookie('SESSION_COOKIE_NAME_PREFIX');
+                if (!prefix || [`""`, `''`].indexOf(prefix) > -1) {
+                    prefix = '';
+                }
+                const csrf = getCookie(`${prefix}csrftoken`);
                 $.ajax({
                     url: apiUrl,
                     method: 'POST',


### PR DESCRIPTION
Fix the issue where the createFaceCaptureToken method in face_capture.html retrieves the CSRF token with a fixed jms_ prefix when the SESSION_COOKIE_DOMAIN parameter of the Core component is configured.