### PR TITLE
fix: face_capature_create_token

### DIFF
--- a/apps/authentication/templates/authentication/face_capture.html
+++ b/apps/authentication/templates/authentication/face_capture.html
@@ -39,7 +39,11 @@
             let token;
 
             function createFaceCaptureToken() {
-                const csrf = getCookie('jms_csrftoken');
+                let prefix = getCookie('SESSION_COOKIE_NAME_PREFIX');
+                if (!prefix || [`""`, `''`].indexOf(prefix) > -1) {
+                    prefix = '';
+                }
+                const csrf = getCookie(`${prefix}csrftoken`);
                 $.ajax({
                     url: apiUrl,
                     method: 'POST',


### PR DESCRIPTION
修复当配置SESSION_COOKIE_DOMAIN时，人脸识别创建连接token时，从Cookie中获取固定 jms_ 的csrftoken码导致校验失败的问题