### PR TITLE
fix: face_capature_create_token

### DIFF
--- a/apps/authentication/templates/authentication/face_capture.html
+++ b/apps/authentication/templates/authentication/face_capture.html
@@ -39,7 +39,11 @@
             let token;
 
             function createFaceCaptureToken() {
-                const csrf = getCookie('jms_csrftoken');
+                let prefix = getCookie('SESSION_COOKIE_NAME_PREFIX');
+                if (!prefix || [`""`, `''`].includes(prefix)) {
+                    prefix = '';
+                }
+                const csrf = getCookie(`${prefix}csrftoken`);
                 $.ajax({
                     url: apiUrl,
                     method: 'POST',


### PR DESCRIPTION
修复问题：当配置SESSION_COOKIE_DOMAIN后，人脸识别创建token时固定按 jms_ 前缀从Cookie取csrftoken码，导致校验失败