### PR TITLE
fix(authentication): validate post-auth redirect URLs

### DIFF
--- a/apps/authentication/api/custom_sso.py
+++ b/apps/authentication/api/custom_sso.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from rest_framework.permissions import AllowAny
 
 from rbac.models import SystemRole, SystemRoleBinding
-from common.utils import get_logger
+from common.utils import get_logger, safe_next_url
 from ..mixins import AuthMixin
 
 __all__  = ['CustomSSOLoginAPIView']
@@ -55,7 +55,7 @@ class CustomSSOLoginAPIView(AuthMixin, RetrieveAPIView):
         if user:
             login(request, user, backend=settings.AUTH_BACKEND_CUSTOM_SSO)
             self.send_auth_signal(success=True, user=user)
-            return HttpResponseRedirect(self.next_url)
+            return HttpResponseRedirect(safe_next_url(self.next_url, request=request))
         else:
             self.send_auth_signal(success=False, reason=error)
             return Response({'detail': error}, status=status.HTTP_401_UNAUTHORIZED)

--- a/apps/authentication/api/sso.py
+++ b/apps/authentication/api/sso.py
@@ -41,6 +41,15 @@ class SSOViewSet(AuthMixin, JMSGenericViewSet):
         'login_url': 'authentication.add_ssotoken',
     }
 
+    @staticmethod
+    def get_safe_next_url(request):
+        query_params = getattr(request, 'query_params', request.GET)
+        raw_next_url = query_params.get(NEXT_URL)
+        next_url = safe_next_url(raw_next_url, request=request)
+        if not raw_next_url or next_url == '/':
+            next_url = reverse('index')
+        return next_url
+
     @action(methods=[POST], detail=False, url_path='login-url')
     def login_url(self, request, *args, **kwargs):
         if not settings.AUTH_SSO:
@@ -73,9 +82,7 @@ class SSOViewSet(AuthMixin, JMSGenericViewSet):
         status_code = status.HTTP_400_BAD_REQUEST
         request.META['HTTP_X_JMS_LOGIN_TYPE'] = 'W'
         authkey = request.query_params.get(AUTH_KEY)
-        next_url = request.query_params.get(NEXT_URL)
-        if not next_url or not next_url.startswith('/'):
-            next_url = reverse('index')
+        next_url = self.get_safe_next_url(request)
 
         try:
             if not authkey:

--- a/apps/authentication/tests.py
+++ b/apps/authentication/tests.py
@@ -1,8 +1,7 @@
-from common.utils import gen_key_pair, rsa_decrypt, rsa_encrypt
+from common.utils import gen_key_pair, reverse, rsa_decrypt, rsa_encrypt
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from authentication.api.sso import SSOViewSet
-from common.utils import reverse
 from users.views.profile.password import UserVerifyPasswordView
 
 
@@ -25,7 +24,10 @@ class SSOLoginRedirectTests(SimpleTestCase):
 
     @override_settings(ALLOWED_HOSTS=['testserver'])
     def test_scheme_relative_next_url_is_rejected(self):
-        request = self.factory.get('/api/v1/authentication/sso/login/', {'next': '//attacker.example.com'})
+        request = self.factory.get(
+            '/api/v1/authentication/sso/login/',
+            {'next': '//attacker.example.com'}
+        )
 
         self.assertEqual(SSOViewSet.get_safe_next_url(request), reverse('index'))
 
@@ -43,7 +45,10 @@ class UserVerifyPasswordRedirectTests(SimpleTestCase):
 
     @override_settings(ALLOWED_HOSTS=['testserver'])
     def test_scheme_relative_next_url_is_rejected(self):
-        request = self.factory.get('/core/auth/password/verify/', {'next': '//attacker.example.com'})
+        request = self.factory.get(
+            '/core/auth/password/verify/',
+            {'next': '//attacker.example.com'}
+        )
         view = UserVerifyPasswordView()
         view.request = request
 

--- a/apps/authentication/tests.py
+++ b/apps/authentication/tests.py
@@ -1,4 +1,9 @@
 from common.utils import gen_key_pair, rsa_decrypt, rsa_encrypt
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from authentication.api.sso import SSOViewSet
+from common.utils import reverse
+from users.views.profile.password import UserVerifyPasswordView
 
 
 def test_rsa_encrypt_decrypt(message='test-password-$%^&*'):
@@ -13,3 +18,41 @@ def test_rsa_encrypt_decrypt(message='test-password-$%^&*'):
     print('Decrypted message: {}'.format(message_decrypted))
 
 
+class SSOLoginRedirectTests(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(ALLOWED_HOSTS=['testserver'])
+    def test_scheme_relative_next_url_is_rejected(self):
+        request = self.factory.get('/api/v1/authentication/sso/login/', {'next': '//attacker.example.com'})
+
+        self.assertEqual(SSOViewSet.get_safe_next_url(request), reverse('index'))
+
+    @override_settings(ALLOWED_HOSTS=['testserver'])
+    def test_local_next_url_is_preserved(self):
+        request = self.factory.get('/api/v1/authentication/sso/login/', {'next': '/ui/#/workbench'})
+
+        self.assertEqual(SSOViewSet.get_safe_next_url(request), '/ui/#/workbench')
+
+
+class UserVerifyPasswordRedirectTests(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(ALLOWED_HOSTS=['testserver'])
+    def test_scheme_relative_next_url_is_rejected(self):
+        request = self.factory.get('/core/auth/password/verify/', {'next': '//attacker.example.com'})
+        view = UserVerifyPasswordView()
+        view.request = request
+
+        self.assertEqual(view.get_success_url(), '/')
+
+    @override_settings(ALLOWED_HOSTS=['testserver'])
+    def test_local_next_url_is_preserved(self):
+        request = self.factory.get('/core/auth/password/verify/', {'next': '/ui/#/profile/index'})
+        view = UserVerifyPasswordView()
+        view.request = request
+
+        self.assertEqual(view.get_success_url(), '/ui/#/profile/index')

--- a/apps/users/views/profile/password.py
+++ b/apps/users/views/profile/password.py
@@ -7,7 +7,7 @@ from django.views.generic.edit import FormView
 
 from authentication import errors
 from authentication.mixins import AuthMixin
-from common.utils import get_logger
+from common.utils import get_logger, safe_next_url
 from ... import forms
 from ...utils import (
     get_user_or_pre_auth_user,
@@ -45,9 +45,9 @@ class UserVerifyPasswordView(AuthMixin, FormView):
         referer = self.request.META.get('HTTP_REFERER')
         next_url = self.request.GET.get("next")
         if next_url:
-            return next_url
+            return safe_next_url(next_url, request=self.request)
         else:
-            return referer
+            return safe_next_url(referer, request=self.request)
 
     def get_context_data(self, **kwargs):
         context = {


### PR DESCRIPTION
This PR hardens post-authentication redirects by routing SSO, custom SSO, and password verification redirects through the existing safe_next_url helper.

Previously, the SSO callback accepted any next value that started with "/". Scheme-relative URLs such as //attacker.example.com therefore passed the check and were sent to HttpResponseRedirect after a successful login. The custom SSO and password verification flows also returned redirect targets without the same host validation.

The fix reuses safe_next_url(), which is already backed by Django's url_has_allowed_host_and_scheme, and adds regression tests to ensure external scheme-relative URLs are rejected while normal local UI paths are preserved.

Security disclosure note:
Vulnerability report has been emailed to official security contact email ibuler@fit2cloud.com in advance, waiting for reply.