### PR TITLE
feat: extend DRF filtering lookups globally

### DIFF
--- a/apps/common/drf/filters.py
+++ b/apps/common/drf/filters.py
@@ -4,11 +4,14 @@ from rest_framework.filters import SearchFilter as SearchFilterBase
 import base64
 import json
 import logging
+from functools import reduce
+from operator import and_, or_
 from collections import defaultdict
 from django.utils import timezone
 
 from django.core.cache import cache
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
+from django.db import models
 from django.db.models import Q
 from django_filters import rest_framework as drf_filters
 from rest_framework import filters
@@ -23,6 +26,7 @@ from common.db.fields import RelatedManager
 logger = logging.getLogger("jumpserver.common")
 
 __all__ = [
+    "LookupFilterBackend",
     "DatetimeRangeFilterBackend",
     "IDSpmFilterBackend",
     "IDInFilterBackend",
@@ -36,12 +40,195 @@ __all__ = [
 ]
 
 
+class LookupFilterBackend(drf_filters.DjangoFilterBackend):
+    """
+    Preserve django-filter's default behavior while allowing explicit
+    text lookups like ``field__icontains=value`` without per-view wiring.
+    """
+    dynamic_text_lookups = {"icontains", "startswith"}
+    dynamic_value_lookups = {"in"}
+    negated_text_lookups = {"icontains", "startswith"}
+    negated_value_lookups = {"exact", "in"}
+
+    def filter_queryset(self, request, queryset, view):
+        queryset = super().filter_queryset(request, queryset, view)
+        queryset = self.filter_dynamic_text_lookups(request, queryset)
+        queryset = self.filter_dynamic_value_lookups(request, queryset)
+        return self.filter_dynamic_negated_lookups(request, queryset)
+
+    def filter_dynamic_text_lookups(self, request, queryset):
+        model = getattr(queryset, "model", None)
+        if model is None:
+            return queryset
+
+        for param, values in request.query_params.lists():
+            if "__" not in param:
+                continue
+
+            field_name, lookup = param.rsplit("__", 1)
+            if lookup not in self.dynamic_text_lookups:
+                continue
+            if not self.is_text_lookup_field(model, field_name):
+                continue
+
+            for value in values:
+                if value == "":
+                    continue
+                queryset = queryset.filter(**{param: value})
+        return queryset
+
+    def is_text_lookup_field(self, model, field_path):
+        field = self.resolve_model_field(model, field_path)
+        return isinstance(field, (models.CharField, models.TextField))
+
+    def filter_dynamic_value_lookups(self, request, queryset):
+        model = getattr(queryset, "model", None)
+        if model is None:
+            return queryset
+
+        for param, values in request.query_params.lists():
+            if "__" not in param:
+                continue
+
+            field_name, lookup = param.rsplit("__", 1)
+            if lookup not in self.dynamic_value_lookups:
+                continue
+            if not self.is_value_lookup_field(model, field_name):
+                continue
+
+            cleaned_values = []
+            for value in values:
+                if value == "":
+                    continue
+                cleaned_values.extend(
+                    item.strip() for item in value.split(",") if item.strip()
+                )
+
+            if cleaned_values:
+                queryset = queryset.filter(**{param: cleaned_values})
+        return queryset
+
+    def is_value_lookup_field(self, model, field_path):
+        field = self.resolve_model_field(model, field_path)
+        if field is None:
+            return False
+        return not getattr(field, "is_relation", False)
+
+    def filter_dynamic_negated_lookups(self, request, queryset):
+        model = getattr(queryset, "model", None)
+        if model is None:
+            return queryset
+
+        for raw_param, values in request.query_params.lists():
+            if not raw_param.endswith("!"):
+                continue
+
+            param = raw_param[:-1]
+            field_name, lookup = self.split_lookup_param(param)
+            if lookup in self.negated_text_lookups:
+                if not self.is_text_lookup_field(model, field_name):
+                    continue
+                for value in values:
+                    if value == "":
+                        continue
+                    queryset = queryset.exclude(**{param: value})
+                continue
+
+            if lookup in self.negated_value_lookups:
+                if not self.is_value_lookup_field(model, field_name):
+                    continue
+                if lookup == "in":
+                    cleaned_values = self.split_csv_values(values)
+                    if cleaned_values:
+                        queryset = queryset.exclude(**{param: cleaned_values})
+                else:
+                    for value in values:
+                        if value == "":
+                            continue
+                        queryset = queryset.exclude(**{field_name: value})
+        return queryset
+
+    @staticmethod
+    def split_lookup_param(param):
+        if "__" not in param:
+            return param, "exact"
+        return param.rsplit("__", 1)
+
+    @staticmethod
+    def split_csv_values(values):
+        cleaned_values = []
+        for value in values:
+            if value == "":
+                continue
+            cleaned_values.extend(
+                item.strip() for item in value.split(",") if item.strip()
+            )
+        return cleaned_values
+
+    def resolve_model_field(self, model, field_path):
+        current_model = model
+        field = None
+        field_names = field_path.split("__")
+
+        for index, field_name in enumerate(field_names):
+            try:
+                field = current_model._meta.get_field(field_name)
+            except FieldDoesNotExist:
+                return None
+
+            if index == len(field_names) - 1:
+                return field
+
+            if not getattr(field, "is_relation", False) or not field.related_model:
+                return None
+            current_model = field.related_model
+
+        return field
+
+
 class SearchFilter(SearchFilterBase):
+    @staticmethod
+    def split_search_groups(params):
+        groups = []
+        for group in params.replace('\x00', '').split(','):
+            terms = [term for term in group.split() if term]
+            if terms:
+                groups.append(terms)
+        return groups
+
     def get_search_terms(self, request):
         params = request.query_params.get(self.search_param, '') or request.query_params.get('search', '')
         params = params.replace('\x00', '')  # strip null characters
-        params = params.replace(',', ' ')
         return params.split()
+
+    def filter_queryset(self, request, queryset, view):
+        search_fields = self.get_search_fields(view, request)
+        raw_params = request.query_params.get(self.search_param, '') or request.query_params.get('search', '')
+        search_groups = self.split_search_groups(raw_params)
+
+        if not search_fields or not search_groups:
+            return queryset
+
+        orm_lookups = [
+            self.construct_search(str(search_field), queryset)
+            for search_field in search_fields
+        ]
+
+        group_conditions = []
+        for terms in search_groups:
+            term_conditions = []
+            for term in terms:
+                queries = [Q(**{orm_lookup: term}) for orm_lookup in orm_lookups]
+                term_conditions.append(reduce(or_, queries))
+            group_conditions.append(reduce(and_, term_conditions))
+
+        queryset = queryset.filter(reduce(or_, group_conditions))
+
+        if self.must_call_distinct(queryset, search_fields):
+            queryset = queryset.filter(pk=models.OuterRef('pk'))
+            queryset = view.get_queryset().filter(models.Exists(queryset))
+
+        return queryset
 
 
 class BaseFilterSet(drf_filters.FilterSet):
@@ -176,6 +363,11 @@ class IDSpmFilterBackend(filters.BaseFilterBackend):
 
 
 class IDInFilterBackend(filters.BaseFilterBackend):
+    """
+    Deprecated compatibility backend.
+
+    Prefer the generic ``id__in=1,2,3`` syntax provided by LookupFilterBackend.
+    """
     def get_schema_fields(self, view):
         return [
             coreapi.Field(
@@ -184,7 +376,7 @@ class IDInFilterBackend(filters.BaseFilterBackend):
                 required=False,
                 type="string",
                 example="/api/v1/users/users?ids=1,2,3",
-                description="Filter by id set",
+                description="Deprecated: filter by id set, prefer id__in",
             )
         ]
 
@@ -192,12 +384,21 @@ class IDInFilterBackend(filters.BaseFilterBackend):
         ids = request.query_params.get("ids")
         if not ids:
             return queryset
+        logger.warning(
+            'Deprecated filter param "ids" used on %s, prefer "id__in"',
+            request.path,
+        )
         id_list = [i.strip() for i in ids.split(",")]
         queryset = queryset.filter(id__in=id_list)
         return queryset
 
 
 class IDNotFilterBackend(filters.BaseFilterBackend):
+    """
+    Deprecated compatibility backend.
+
+    Prefer the generic ``id__in!=1,2,3`` syntax provided by LookupFilterBackend.
+    """
     def get_schema_fields(self, view):
         return [
             coreapi.Field(
@@ -206,7 +407,7 @@ class IDNotFilterBackend(filters.BaseFilterBackend):
                 required=False,
                 type="string",
                 example="/api/v1/users/users?id!=1,2,3",
-                description="Exclude by id set",
+                description="Deprecated: exclude by id set, prefer id__in!",
             )
         ]
 
@@ -214,6 +415,10 @@ class IDNotFilterBackend(filters.BaseFilterBackend):
         ids = request.query_params.get("id!")
         if not ids:
             return queryset
+        logger.warning(
+            'Deprecated filter param "id!" used on %s, prefer "id__in!"',
+            request.path,
+        )
         id_list = [i.strip() for i in ids.split(",")]
         queryset = queryset.exclude(id__in=id_list)
         return queryset

--- a/apps/common/tests.py
+++ b/apps/common/tests.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
+from users.models import User
 
 # Create your tests here.
 
+from common.drf.filters import LookupFilterBackend
 from .utils import random_string, signer
 
 
@@ -13,3 +15,76 @@ def test_signer_len():
         results[i] = (len(encs)/len(s))
     results = sorted(results.items(), key=lambda x: x[1], reverse=True)
     print(results)
+
+
+class LookupFilterBackendTests(TestCase):
+    def setUp(self):
+        self.backend = LookupFilterBackend()
+
+    def test_is_text_lookup_field_for_text_fields(self):
+        self.assertTrue(self.backend.is_text_lookup_field(User, "username"))
+        self.assertTrue(self.backend.is_text_lookup_field(User, "name"))
+
+    def test_is_text_lookup_field_for_non_text_fields(self):
+        self.assertFalse(self.backend.is_text_lookup_field(User, "id"))
+
+    def test_is_text_lookup_field_for_related_field(self):
+        self.assertTrue(self.backend.is_text_lookup_field(User, "groups__name"))
+        self.assertFalse(self.backend.is_text_lookup_field(User, "groups__id"))
+
+    def test_supported_dynamic_text_lookups(self):
+        self.assertEqual(
+            self.backend.dynamic_text_lookups,
+            {"icontains", "startswith"}
+        )
+
+    def test_supported_dynamic_value_lookups(self):
+        self.assertEqual(
+            self.backend.dynamic_value_lookups,
+            {"in"}
+        )
+
+    def test_supported_negated_text_lookups(self):
+        self.assertEqual(
+            self.backend.negated_text_lookups,
+            {"icontains", "startswith"}
+        )
+
+    def test_supported_negated_value_lookups(self):
+        self.assertEqual(
+            self.backend.negated_value_lookups,
+            {"exact", "in"}
+        )
+
+    def test_is_value_lookup_field(self):
+        self.assertTrue(self.backend.is_value_lookup_field(User, "username"))
+        self.assertTrue(self.backend.is_value_lookup_field(User, "id"))
+        self.assertFalse(self.backend.is_value_lookup_field(User, "groups"))
+
+    def test_split_lookup_param(self):
+        self.assertEqual(
+            self.backend.split_lookup_param("username"),
+            ("username", "exact")
+        )
+        self.assertEqual(
+            self.backend.split_lookup_param("username__icontains"),
+            ("username", "icontains")
+        )
+
+    def test_split_csv_values(self):
+        self.assertEqual(
+            self.backend.split_csv_values(["alice, bob", "carol"]),
+            ["alice", "bob", "carol"]
+        )
+
+    def test_search_filter_split_search_groups(self):
+        from common.drf.filters import SearchFilter
+
+        self.assertEqual(
+            SearchFilter.split_search_groups("alice,bob"),
+            [["alice"], ["bob"]]
+        )
+        self.assertEqual(
+            SearchFilter.split_search_groups("alice admin,bob"),
+            [["alice", "admin"], ["bob"]]
+        )

--- a/apps/jumpserver/settings/libs.py
+++ b/apps/jumpserver/settings/libs.py
@@ -48,7 +48,7 @@ REST_FRAMEWORK = {
         'file_transfer': CONFIG.THROTTLE_FILE_TRANSFER,
     },
     'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
+        'common.drf.filters.LookupFilterBackend',
         'common.drf.filters.SearchFilter',
         'common.drf.filters.RewriteOrderingFilter',
     ),


### PR DESCRIPTION
- add a shared LookupFilterBackend on top of django-filter\n- support explicit icontains, startswith, in and negated lookups globally\n- allow comma-separated q/search groups to behave like OR/in-style search\n- keep ids and id! as deprecated compatibility aliases with warnings\n- add tests for lookup parsing helpers and search grouping

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.