### PR TITLE
feat: support Elasticsearch 9 for command storage

### DIFF
--- a/apps/common/plugins/es.py
+++ b/apps/common/plugins/es.py
@@ -66,9 +66,9 @@ class ESClient(object):
         version = get_es_client_version(**kwargs)
         if version == 6:
             return ESClientV6(*args, **kwargs)
-        if version == 7:
+        elif version == 7:
             return ESClientV7(*args, **kwargs)
-        elif version == 8:
+        elif version in (8, 9):
             return ESClientV8(*args, **kwargs)
         raise ValueError('Unsupported ES_VERSION %r' % version)
 


### PR DESCRIPTION
## 摘要
- ES 客户端工厂支持主版本 9，复用现有 `ESClientV8`（elasticsearch8）
- 解决对接 ES 9 时命令存储校验失败、会话 `invalid_elasticsearch` 的问题

## 变更
- `apps/common/plugins/es.py`：`version in (8, 9)` 时返回 `ESClientV8`

## 测试计划
- [ ] ES 9 命令存储连通测试通过
- [ ] 建会话不再报 `Unsupported ES_VERSION 9`
- [ ] 审计侧可查询 ES 中的命令
- [ ] ES 7/8 回归正常