### PR TITLE
ci: pass branch names through env and quote the push refspecs

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -91,6 +91,9 @@ jobs:
           sed -i 's|-base:.* AS stage-build|-base:${{ env.IMAGE_TAG }} AS stage-build|' Dockerfile
 
       - name: Commit changes
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_BRANCH: ${{ inputs.branch }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             echo "No changes to commit."
@@ -101,9 +104,9 @@ jobs:
           git add Dockerfile
           git commit -m "perf: Update Dockerfile with new base image tag"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            git push origin HEAD:"$HEAD_REF"
           else
-            git push origin HEAD:${{ inputs.branch }}
+            git push origin HEAD:"$INPUT_BRANCH"
           fi
         if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork == false }}
         env:


### PR DESCRIPTION
Hi, and thanks for JumpServer.

In `.github/workflows/build-base-image.yml`, the "Commit changes" step pushes to a branch whose name is interpolated straight into the command, unquoted:

```yaml
if [ "${{ github.event_name }}" = "pull_request" ]; then
  git push origin HEAD:${{ github.event.pull_request.head.ref }}
else
  git push origin HEAD:${{ inputs.branch }}
fi
```

Actions expands `${{ ... }}` into the script text before bash runs, so the branch name lands as script rather than as an argument. Git allows `$`, `(`, `)`, backticks and spaces in branch names, and `$(...)` executes inside double quotes — so a branch named something like `x$(id)` would run that on the runner, and a name containing a space would split into two arguments and push somewhere unintended.

The change passes both values through `env:` and quotes the refspecs:

```yaml
env:
  HEAD_REF: ${{ github.event.pull_request.head.ref }}
  INPUT_BRANCH: ${{ inputs.branch }}
run: |
  ...
  git push origin HEAD:"$HEAD_REF"
  ...
  git push origin HEAD:"$INPUT_BRANCH"
```

Same two pushes, same branches. I left `github.event_name` interpolated on purpose — that is a fixed GitHub-controlled string, not free text.

One thing I could not determine from outside and would rather ask than assume: whether this workflow runs for pull requests opened from forks. On a plain `pull_request` event a fork gets a read-only token, which bounds this considerably; if it is reachable another way, it matters more. You will know that better than I do.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
