### PR TITLE
修复V3对接es后，通过资产搜索命令展示结果混乱的问题

### DIFF
--- a/apps/common/plugins/es.py
+++ b/apps/common/plugins/es.py
@@ -114,7 +114,7 @@ def get_es_client_version(**kwargs):
 
 class ES(object):
 
-    def __init__(self, config, properties, keyword_fields, exact_fields=None, match_fields=None):
+    def __init__(self, config, properties, keyword_fields, exact_fields=None, fuzzy_fields=None, match_fields=None):
         self.version = 7
         self.config = config
         hosts = self.config.get('HOSTS')
@@ -131,12 +131,14 @@ class ES(object):
         self.index = None
         self.query_index = None
         self.properties = properties
-        self.exact_fields, self.match_fields, self.keyword_fields = set(), set(), set()
+        self.exact_fields, self.match_fields, self.keyword_fields, self.fuzzy_fields = set(), set(), set(), set()
 
         if isinstance(keyword_fields, Iterable):
             self.keyword_fields.update(keyword_fields)
         if isinstance(exact_fields, Iterable):
             self.exact_fields.update(exact_fields)
+        if isinstance(fuzzy_fields, Iterable):
+            self.fuzzy_fields.update(fuzzy_fields)
         if isinstance(match_fields, Iterable):
             self.match_fields.update(match_fields)
 
@@ -306,6 +308,13 @@ class ES(object):
             })
         return _filter
 
+    @staticmethod
+    def handle_fuzzy_fields(exact):
+        _filter = []
+        for k, v in exact.items():
+            _filter.append({'wildcard': {k: f'*{v}*'}})
+        return _filter
+
     def get_query_body(self, **kwargs):
         new_kwargs = {}
         for k, v in kwargs.items():
@@ -321,9 +330,11 @@ class ES(object):
         index_in_field = 'id__in'
         exact_fields = self.exact_fields
         match_fields = self.match_fields
+        fuzzy_fields = self.fuzzy_fields
 
         match = {}
         exact = {}
+        fuzzy = {}
         index = {}
 
         if index_in_field in kwargs:
@@ -332,6 +343,8 @@ class ES(object):
         for k, v in kwargs.items():
             if k in exact_fields:
                 exact[k] = v
+            elif k in fuzzy_fields:
+                fuzzy[f"{k}.keyword"] = v
             elif k in match_fields:
                 match[k] = v
 
@@ -368,6 +381,7 @@ class ES(object):
                     ],
                     'should': should,
                     'filter': self.handle_exact_fields(exact) +
+                              self.handle_fuzzy_fields(fuzzy) +
                               [
                                   {
                                       'range': {

--- a/apps/terminal/backends/command/es.py
+++ b/apps/terminal/backends/command/es.py
@@ -28,10 +28,11 @@ class CommandStore(ES):
             }
         }
         exact_fields = {}
-        match_fields = {'input', 'risk_level', 'user', 'asset', 'system_user'}
+        fuzzy_fields = {'input', 'user', 'asset', 'system_user'}
+        match_fields = {'input', 'risk_level'}
         keyword_fields = {'session', 'org_id'}
 
-        super().__init__(config, properties, keyword_fields, exact_fields, match_fields)
+        super().__init__(config, properties, keyword_fields, exact_fields, fuzzy_fields, match_fields)
 
     @staticmethod
     def make_data(command):


### PR DESCRIPTION
**背景**
当前版本（v3.10.21）对接 Elasticsearch 后，在命令记录页面通过资产（asset）筛选时出现完全不相干的查询结果。对比 v4 版本定位到根因：asset、user、system_user 字段使用了 ES 的 match 查询，该查询对 text 类型字段做分词匹配，导致无法精确筛选。

**根因分析**
match 查询会将 text 字段值进行分词，例如资产名 "web-server-01" 被拆分为 ["web", "server", "01"] 三个 token，ES 匹配任意一个 token 即返回，导致筛选结果中混入大量不相关记录。

**解决方案**
引入 fuzzy_fields 机制：使用 ES 的 wildcard 查询 + .keyword 子字段，实现不分词的精确子串匹配，确保筛选结果精准。（与V4逻辑统一， V4暂无该问题）
**涉及文件及改动明细**
文件 1：apps/terminal/backends/command/es.py
改动位置：CommandStore.__init__ 方法（第 30-35 行）

改动说明：重构字段分类，将 user、asset、system_user 从 match_fields 迁移至新增的 fuzzy_fields，并在 super().__init__() 中传入该参数。

文件 2：apps/common/plugins/es.py
共 3 处改动：

改动 2.1：ES.__init__ 方法签名及初始化（第 117-143 行）
改动说明：新增 fuzzy_fields 参数，并将其初始化到实例属性中。
改动 2.2：ES 类新增 handle_fuzzy_fields 静态方法（第 312-316 行，紧接 handle_exact_fields 之后）
改动说明：新增静态方法，对传入的字段值生成 wildcard + .keyword 查询，实现不分词精确子串匹配。
改动 2.3：ES.get_query_body 方法（第 317-395 行）
改动说明：在查询体构造逻辑中增加 fuzzy_fields 的处理分支——字段值路由到 fuzzy 字典（使用 .keyword 子字段），并在构建 filter 子句时拼接 handle_fuzzy_fields(fuzzy) 的结果。


**影响范围**
仅影响：对接 Elasticsearch 后的命令记录模块（CommandStore）
不影响：无 ES 对接的命令查询逻辑、MySQL 存储后端、其他使用 plugins/es.py 的模块（因为 fuzzy_fields=None 默认值为空，其他子类不会受影响）
向后兼容：fuzzy_fields 参数默认为 None，未显式传入的情况下行为与修复前完全一致