### PR TITLE
fix: restore IPython in EE images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ dev = [
 ]
 
 xpack = [
+    'ipython==8.30.0',
     "requests-unixsocket==0.4.1",
     'qingcloud-sdk==1.2.15',
     'azure-mgmt-subscription==3.1.1',


### PR DESCRIPTION
#### What this PR does / why we need it?
4.10.17 开始 Django Shell 由于缺少了 IPython 所以 Django 自动回退到了普通 Python Shell
#### Summary of your change
在 xpack 依赖中添加了 IPython
#### Please indicate you've done the following:

- [ x ] Made sure tests are passing and test coverage is added if needed.
- [ x ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.