### PR TITLE
fix: hide generated history model import warnings

### DIFF
--- a/apps/accounts/models/account.py
+++ b/apps/accounts/models/account.py
@@ -63,7 +63,9 @@ class AccountHistoricalRecords(HistoricalRecords):
                 field.name for field in model._meta.fields
                 if field.name not in self.included_fields
             ]
-        return super().create_history_model(model, inherited)
+        history_model = super().create_history_model(model, inherited)
+        history_model.__module__ = model.__module__
+        return history_model
 
 
 class JSONFilterMixin:

--- a/apps/ops/models/job.py
+++ b/apps/ops/models/job.py
@@ -143,6 +143,13 @@ class JMSPermedInventory(JMSInventory):
         return mapper
 
 
+class JobHistoricalRecords(HistoricalRecords):
+    def create_history_model(self, model, inherited):
+        history_model = super().create_history_model(model, inherited)
+        history_model.__module__ = model.__module__
+        return history_model
+
+
 class Job(JMSOrgBaseModel, PeriodTaskModelMixin):
     name = models.CharField(max_length=128, null=True, verbose_name=_('Name'))
     instant = models.BooleanField(default=False)
@@ -164,7 +171,7 @@ class Job(JMSOrgBaseModel, PeriodTaskModelMixin):
                                     verbose_name=_('Run as policy'))
     comment = models.CharField(max_length=1024, default='', verbose_name=_('Comment'), null=True, blank=True)
     version = models.IntegerField(default=0)
-    history = HistoricalRecords()
+    history = JobHistoricalRecords()
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
#### What this PR does / why we need it?
升级 Django 5.2 后，执行 python manage.py shell 会出现以下提示：
<img width="2550" height="562" alt="image" src="https://github.com/user-attachments/assets/02c613ba-9af5-436e-8c1a-1948ad452062" />
2 objects could not be automatically imported:

  ops.HistoricalJob
  accounts.HistoricalAccount

django-simple-history 生成的历史模型使用了无法直接导入的模块路径，导致 Django Shell 自动导入失败。
#### Summary of your change
将 HistoricalAccount 的模块路径修正为 accounts.models.account
将 HistoricalJob 的模块路径修正为 ops.models.job
保留 Django 默认的模型自动导入功能
不修改数据库结构、表名及迁移文件
#### Please indicate you've done the following:

- [ x ] Made sure tests are passing and test coverage is added if needed.
- [ x ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.