### PR TITLE
fix: filter username hints by effective account permissions

### DIFF
--- a/apps/ops/api/job.py
+++ b/apps/ops/api/job.py
@@ -1,12 +1,12 @@
 import json
 import os
 import uuid
+from collections import Counter
 from functools import partial
 
 from celery.result import AsyncResult
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Count
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils._os import safe_join
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from acls.models import LoginAssetACL
+from assets.const import Protocol
 from assets.models import Asset
 from common.const.http import POST
 from common.drf.throttling import FileTransferThrottle
@@ -42,7 +43,8 @@ from ops.variables import JMS_JOB_VARIABLE_HELP
 from ops.const import COMMAND_EXECUTION_DISABLED
 from orgs.mixins.api import OrgBulkModelViewSet
 from orgs.utils import tmp_to_org, get_current_org
-from accounts.models import Account
+from perms.const import ActionChoices
+from perms.utils.asset_perm import PermAssetDetailUtil
 from jumpserver.settings import get_file_md5
 
 
@@ -320,6 +322,49 @@ class JobRunVariableHelpAPIView(APIView):
 class UsernameHintsAPI(APIView):
     permission_classes = [IsValidUser]
 
+    upload_protocols = {Protocol.ssh, Protocol.sftp, Protocol.winrm}
+
+    @staticmethod
+    def is_account_permitted(account, action_required):
+        return (
+            not account.is_virtual()
+            and ActionChoices.contains(account.actions, action_required)
+            and not account.username.startswith(('jms_', 'js_'))
+        )
+
+    @classmethod
+    def get_asset_permed_account_usernames(
+        cls, user, asset, action_required, protocols_required=None,
+    ):
+        permitted_protocols = set(
+            asset.protocols.values_list('name', flat=True)
+        )
+        if protocols_required:
+            permitted_protocols &= protocols_required
+        if not permitted_protocols:
+            return []
+
+        util = PermAssetDetailUtil(user, asset)
+        if not util.check_perm_protocols(permitted_protocols):
+            return []
+
+        return [
+            account.username
+            for account in util.get_permed_accounts_for_user()
+            if cls.is_account_permitted(account, action_required)
+        ]
+
+    @classmethod
+    def get_permed_account_usernames(
+        cls, user, assets, action_required, protocols_required=None,
+    ):
+        usernames = []
+        for asset in assets:
+            usernames.extend(cls.get_asset_permed_account_usernames(
+                user, asset, action_required, protocols_required,
+            ))
+        return usernames
+
     def post(self, request, **kwargs):
         if settings.SAFE_MODE:
             return Response(data=[])
@@ -330,15 +375,34 @@ class UsernameHintsAPI(APIView):
         assets = list(Asset.objects.filter(id__in=asset_ids).all())
 
         assets = merge_nodes_and_assets(node_ids, assets, request.user)
+        is_upload = request.data.get('action') == 'upload'
+        action_required = (
+            ActionChoices.upload.value
+            if is_upload else ActionChoices.connect.value
+        )
+        protocols_required = self.upload_protocols if is_upload else None
+        usernames = self.get_permed_account_usernames(
+            request.user,
+            assets,
+            action_required,
+            protocols_required,
+        )
+        if query:
+            query = str(query).lower()
+            usernames = [
+                username for username in usernames
+                if query in username.lower()
+            ]
 
-        top_accounts = Account.objects \
-            .exclude(username__startswith='jms_') \
-            .exclude(username__startswith='js_') \
-            .filter(username__icontains=query) \
-            .filter(asset__in=assets) \
-            .values('username') \
-            .annotate(total=Count('username')) \
-            .order_by('-total', '-username')[:10]
+        counts = Counter(usernames)
+        top_accounts = [
+            {'username': username, 'total': total}
+            for username, total in sorted(
+                counts.items(),
+                key=lambda item: (item[1], item[0]),
+                reverse=True,
+            )[:10]
+        ]
         return Response(data=top_accounts)
 
 

--- a/apps/ops/tests/test_username_hints.py
+++ b/apps/ops/tests/test_username_hints.py
@@ -1,0 +1,145 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+from django.test import TestCase
+from django.utils import timezone
+
+from accounts.models import Account
+from assets.const import Category, HostTypes, Protocol
+from assets.models import Asset, Platform
+from ops.api.job import UsernameHintsAPI
+from orgs.models import Organization
+from orgs.utils import tmp_to_org, tmp_to_root_org
+from perms.const import ActionChoices
+from perms.models import AssetPermission
+from users.models import User
+
+
+class UsernameHintsPermissionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.org, _ = Organization.objects.get_or_create(
+            id=Organization.DEFAULT_ID,
+            defaults={'name': 'DEFAULT', 'builtin': True},
+        )
+        cls.user = User.objects.create(
+            username='file-transfer-user',
+            name='File transfer user',
+        )
+        cls.platform = Platform.objects.create(
+            name='File transfer permission test',
+            category=Category.HOST,
+            type=HostTypes.LINUX,
+        )
+
+    def create_asset(self, name, protocol=Protocol.ssh):
+        with tmp_to_root_org():
+            asset = Asset.objects.create(
+                org_id=self.org.id,
+                name=name,
+                address=f'{name}.example.com',
+                platform=self.platform,
+            )
+            asset.protocols.create(name=protocol, port=22)
+        return asset
+
+    def create_account(self, asset, username):
+        with tmp_to_root_org():
+            return Account.objects.create(
+                org_id=self.org.id,
+                asset=asset,
+                name=username,
+                username=username,
+            )
+
+    def grant(self, name, asset, account, actions):
+        with tmp_to_root_org():
+            permission = AssetPermission.objects.create(
+                org_id=self.org.id,
+                name=name,
+                accounts=[account],
+                protocols=list(
+                    asset.protocols.values_list('name', flat=True)
+                ),
+                actions=actions,
+                date_start=timezone.now() - timedelta(minutes=1),
+                date_expired=timezone.now() + timedelta(days=1),
+            )
+            permission.users.add(self.user)
+            permission.assets.add(asset)
+
+    def get_hints(self, asset, action=None):
+        data = {
+            'nodes': [],
+            'assets': [str(asset.id)],
+            'query': '',
+        }
+        if action:
+            data['action'] = action
+        request = SimpleNamespace(user=self.user, data=data)
+        with tmp_to_org(self.org):
+            response = UsernameHintsAPI().post(request)
+        return list(response.data)
+
+    def test_upload_hints_exclude_accounts_without_upload_permission(self):
+        asset = self.create_asset('upload-asset')
+        self.create_account(asset, 'upload-user')
+        self.create_account(asset, 'connect-only-user')
+        self.create_account(asset, 'ungranted-user')
+        self.grant(
+            'Upload account permission',
+            asset,
+            'upload-user',
+            ActionChoices.connect.value | ActionChoices.upload.value,
+        )
+        self.grant(
+            'Connect account permission',
+            asset,
+            'connect-only-user',
+            ActionChoices.connect.value,
+        )
+        self.grant(
+            'Virtual upload account permission',
+            asset,
+            '@INPUT',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [{'username': 'upload-user', 'total': 1}])
+
+    def test_upload_hints_exclude_assets_without_transfer_protocols(self):
+        asset = self.create_asset('telnet-asset', protocol=Protocol.telnet)
+        self.create_account(asset, 'telnet-user')
+        self.grant(
+            'Telnet upload permission',
+            asset,
+            'telnet-user',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [])
+
+    def test_default_hints_keep_connect_permission_semantics(self):
+        asset = self.create_asset('quick-job-asset')
+        self.create_account(asset, 'connect-user')
+        self.create_account(asset, 'upload-only-user')
+        self.grant(
+            'Connect account permission',
+            asset,
+            'connect-user',
+            ActionChoices.connect.value,
+        )
+        self.grant(
+            'Upload account permission',
+            asset,
+            'upload-only-user',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset)
+
+        self.assertEqual(hints, [{'username': 'connect-user', 'total': 1}])


### PR DESCRIPTION
## What changed

- Build username hints from the request user's effective asset-account permissions instead of all accounts on the selected assets.
- Filter hints by the required action and by protocols available to both the asset and the user's permission.
- Preserve the existing connect-action behavior for callers that do not provide an action, while allowing file transfer callers to request upload-authorized hints.
- Exclude virtual and internal JumpServer accounts from suggestions.

## Why

`UsernameHintsAPI` currently limits assets through `merge_nodes_and_assets`, but then queries every account attached to those assets. This can suggest account usernames that the user was not granted or that do not allow the operation being prepared. Execution-time checks reject those accounts later, so the autocomplete result is both overexposed and inconsistent with execution.

This complements the execution-time file transfer checks added in #17215 by applying the same permission boundary to the hint endpoint.

## Impact

Quick jobs continue to receive connect-authorized hints by default. File transfer clients can pass `action: upload` to receive only upload-authorized hints on SSH, SFTP, or WinRM assets.

## Validation

- Added integration coverage for upload action filtering, transfer protocol filtering, virtual-account exclusion, and the existing quick-job default.
- Ran the existing and new affected Core tests: 8 tests passed.
- Django system checks reported no issues.

## Companion change

- jumpserver/lina#5596
