### PR TITLE
fix: filter username hints by effective account permissions

### DIFF
--- a/apps/ops/api/job.py
+++ b/apps/ops/api/job.py
@@ -44,7 +44,7 @@ from ops.const import COMMAND_EXECUTION_DISABLED
 from orgs.mixins.api import OrgBulkModelViewSet
 from orgs.utils import tmp_to_org, get_current_org
 from perms.const import ActionChoices
-from perms.utils.asset_perm import PermAssetDetailUtil
+from perms.utils.asset_perm import PermAssetAccountsBatchUtil
 from jumpserver.settings import get_file_md5
 
 
@@ -325,45 +325,14 @@ class UsernameHintsAPI(APIView):
     upload_protocols = {Protocol.ssh, Protocol.sftp, Protocol.winrm}
 
     @staticmethod
-    def is_account_permitted(account, action_required):
-        return (
-            not account.is_virtual()
-            and ActionChoices.contains(account.actions, action_required)
-            and not account.username.startswith(('jms_', 'js_'))
-        )
-
-    @classmethod
-    def get_asset_permed_account_usernames(
-        cls, user, asset, action_required, protocols_required=None,
-    ):
-        permitted_protocols = set(
-            asset.protocols.values_list('name', flat=True)
-        )
-        if protocols_required:
-            permitted_protocols &= protocols_required
-        if not permitted_protocols:
-            return []
-
-        util = PermAssetDetailUtil(user, asset)
-        if not util.check_perm_protocols(permitted_protocols):
-            return []
-
-        return [
-            account.username
-            for account in util.get_permed_accounts_for_user()
-            if cls.is_account_permitted(account, action_required)
-        ]
-
-    @classmethod
     def get_permed_account_usernames(
-        cls, user, assets, action_required, protocols_required=None,
+        user, assets, action_required, protocols_required=None,
     ):
-        usernames = []
-        for asset in assets:
-            usernames.extend(cls.get_asset_permed_account_usernames(
-                user, asset, action_required, protocols_required,
-            ))
-        return usernames
+        return PermAssetAccountsBatchUtil(
+            user
+        ).get_permitted_account_usernames(
+            assets, action_required, protocols_required,
+        )
 
     def post(self, request, **kwargs):
         if settings.SAFE_MODE:

--- a/apps/ops/api/job.py
+++ b/apps/ops/api/job.py
@@ -1,12 +1,12 @@
 import json
 import os
 import uuid
+from collections import Counter
 from functools import partial
 
 from celery.result import AsyncResult
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Count
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils._os import safe_join
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from acls.models import LoginAssetACL
+from assets.const import Protocol
 from assets.models import Asset
 from common.const.http import POST
 from common.drf.throttling import FileTransferThrottle
@@ -42,7 +43,8 @@ from ops.variables import JMS_JOB_VARIABLE_HELP
 from ops.const import COMMAND_EXECUTION_DISABLED
 from orgs.mixins.api import OrgBulkModelViewSet
 from orgs.utils import tmp_to_org, get_current_org
-from accounts.models import Account
+from perms.const import ActionChoices
+from perms.utils.asset_perm import PermAssetDetailUtil
 from jumpserver.settings import get_file_md5
 
 
@@ -320,6 +322,49 @@ class JobRunVariableHelpAPIView(APIView):
 class UsernameHintsAPI(APIView):
     permission_classes = [IsValidUser]
 
+    upload_protocols = {Protocol.ssh, Protocol.sftp, Protocol.winrm}
+
+    @staticmethod
+    def is_account_permitted(account, action_required):
+        return (
+            not account.is_virtual()
+            and ActionChoices.contains(account.actions, action_required)
+            and not account.username.startswith(('jms_', 'js_'))
+        )
+
+    @classmethod
+    def get_asset_permed_account_usernames(
+        cls, user, asset, action_required, protocols_required=None,
+    ):
+        permitted_protocols = set(
+            asset.protocols.values_list('name', flat=True)
+        )
+        if protocols_required:
+            permitted_protocols &= protocols_required
+        if not permitted_protocols:
+            return []
+
+        util = PermAssetDetailUtil(user, asset)
+        if not util.check_perm_protocols(permitted_protocols):
+            return []
+
+        return [
+            account.username
+            for account in util.get_permed_accounts_for_user()
+            if cls.is_account_permitted(account, action_required)
+        ]
+
+    @classmethod
+    def get_permed_account_usernames(
+        cls, user, assets, action_required, protocols_required=None,
+    ):
+        usernames = []
+        for asset in assets:
+            usernames.extend(cls.get_asset_permed_account_usernames(
+                user, asset, action_required, protocols_required,
+            ))
+        return usernames
+
     def post(self, request, **kwargs):
         if settings.SAFE_MODE:
             return Response(data=[])
@@ -330,15 +375,34 @@ class UsernameHintsAPI(APIView):
         assets = list(Asset.objects.filter(id__in=asset_ids).all())
 
         assets = merge_nodes_and_assets(node_ids, assets, request.user)
+        is_upload = request.data.get('action') == 'upload'
+        action_required = (
+            ActionChoices.upload.value
+            if is_upload else ActionChoices.connect.value
+        )
+        protocols_required = self.upload_protocols if is_upload else None
+        usernames = self.get_permed_account_usernames(
+            request.user,
+            assets,
+            action_required,
+            protocols_required,
+        )
+        if query:
+            query = str(query).lower()
+            usernames = [
+                username for username in usernames
+                if query in username.lower()
+            ]
 
-        top_accounts = Account.objects \
-            .exclude(username__startswith='jms_') \
-            .exclude(username__startswith='js_') \
-            .filter(username__icontains=query) \
-            .filter(asset__in=assets) \
-            .values('username') \
-            .annotate(total=Count('username')) \
-            .order_by('-total', '-username')[:10]
+        counts = Counter(usernames)
+        top_accounts = [
+            {'username': username, 'total': total}
+            for username, total in sorted(
+                counts.items(),
+                key=lambda item: (item[1], item[0]),
+                reverse=True,
+            )[:10]
+        ]
         return Response(data=top_accounts)
 
 

--- a/apps/ops/tests/test_username_hints.py
+++ b/apps/ops/tests/test_username_hints.py
@@ -1,0 +1,145 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+from django.test import TestCase
+from django.utils import timezone
+
+from accounts.models import Account
+from assets.const import Category, HostTypes, Protocol
+from assets.models import Asset, Platform
+from ops.api.job import UsernameHintsAPI
+from orgs.models import Organization
+from orgs.utils import tmp_to_org, tmp_to_root_org
+from perms.const import ActionChoices
+from perms.models import AssetPermission
+from users.models import User
+
+
+class UsernameHintsPermissionTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.org, _ = Organization.objects.get_or_create(
+            id=Organization.DEFAULT_ID,
+            defaults={'name': 'DEFAULT', 'builtin': True},
+        )
+        cls.user = User.objects.create(
+            username='file-transfer-user',
+            name='File transfer user',
+        )
+        cls.platform = Platform.objects.create(
+            name='File transfer permission test',
+            category=Category.HOST,
+            type=HostTypes.LINUX,
+        )
+
+    def create_asset(self, name, protocol=Protocol.ssh):
+        with tmp_to_root_org():
+            asset = Asset.objects.create(
+                org_id=self.org.id,
+                name=name,
+                address=f'{name}.example.com',
+                platform=self.platform,
+            )
+            asset.protocols.create(name=protocol, port=22)
+        return asset
+
+    def create_account(self, asset, username):
+        with tmp_to_root_org():
+            return Account.objects.create(
+                org_id=self.org.id,
+                asset=asset,
+                name=username,
+                username=username,
+            )
+
+    def grant(self, name, asset, account, actions):
+        with tmp_to_root_org():
+            permission = AssetPermission.objects.create(
+                org_id=self.org.id,
+                name=name,
+                accounts=[account],
+                protocols=list(
+                    asset.protocols.values_list('name', flat=True)
+                ),
+                actions=actions,
+                date_start=timezone.now() - timedelta(minutes=1),
+                date_expired=timezone.now() + timedelta(days=1),
+            )
+            permission.users.add(self.user)
+            permission.assets.add(asset)
+
+    def get_hints(self, asset, action=None):
+        data = {
+            'nodes': [],
+            'assets': [str(asset.id)],
+            'query': '',
+        }
+        if action:
+            data['action'] = action
+        request = SimpleNamespace(user=self.user, data=data)
+        with tmp_to_org(self.org):
+            response = UsernameHintsAPI().post(request)
+        return list(response.data)
+
+    def test_upload_hints_exclude_accounts_without_upload_permission(self):
+        asset = self.create_asset('upload-asset')
+        self.create_account(asset, 'upload-user')
+        self.create_account(asset, 'connect-only-user')
+        self.create_account(asset, 'ungranted-user')
+        self.grant(
+            'Upload account permission',
+            asset,
+            'upload-user',
+            ActionChoices.connect.value | ActionChoices.upload.value,
+        )
+        self.grant(
+            'Connect account permission',
+            asset,
+            'connect-only-user',
+            ActionChoices.connect.value,
+        )
+        self.grant(
+            'Virtual upload account permission',
+            asset,
+            '@INPUT',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [{'username': 'upload-user', 'total': 1}])
+
+    def test_upload_hints_exclude_assets_without_transfer_protocols(self):
+        asset = self.create_asset('telnet-asset', protocol=Protocol.telnet)
+        self.create_account(asset, 'telnet-user')
+        self.grant(
+            'Telnet upload permission',
+            asset,
+            'telnet-user',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [])
+
+    def test_default_hints_keep_connect_permission_semantics(self):
+        asset = self.create_asset('quick-job-asset')
+        self.create_account(asset, 'connect-user')
+        self.create_account(asset, 'upload-only-user')
+        self.grant(
+            'Connect account permission',
+            asset,
+            'connect-user',
+            ActionChoices.connect.value,
+        )
+        self.grant(
+            'Upload account permission',
+            asset,
+            'upload-only-user',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset)
+
+        self.assertEqual(hints, [{'username': 'connect-user', 'total': 1}])

--- a/apps/ops/tests/test_username_hints.py
+++ b/apps/ops/tests/test_username_hints.py
@@ -54,11 +54,11 @@ class UsernameHintsPermissionTest(TestCase):
                 username=username,
             )
 
-    def grant(self, name, asset, account, actions, protocols=None):
+    def grant(self, asset, account, actions, protocols=None):
         with tmp_to_root_org():
             permission = AssetPermission.objects.create(
                 org_id=self.org.id,
-                name=name,
+                name=f'{asset.name}-{account}',
                 accounts=[account],
                 protocols=protocols or list(
                     asset.protocols.values_list('name', flat=True)
@@ -90,19 +90,16 @@ class UsernameHintsPermissionTest(TestCase):
         self.create_account(asset, 'connect-only-user')
         self.create_account(asset, 'ungranted-user')
         self.grant(
-            'Upload account permission',
             asset,
             'upload-user',
             ActionChoices.connect.value | ActionChoices.upload.value,
         )
         self.grant(
-            'Connect account permission',
             asset,
             'connect-only-user',
             ActionChoices.connect.value,
         )
         self.grant(
-            'Virtual upload account permission',
             asset,
             '@INPUT',
             ActionChoices.upload.value,
@@ -116,7 +113,6 @@ class UsernameHintsPermissionTest(TestCase):
         asset = self.create_asset('telnet-asset', protocol=Protocol.telnet)
         self.create_account(asset, 'telnet-user')
         self.grant(
-            'Telnet upload permission',
             asset,
             'telnet-user',
             ActionChoices.upload.value,
@@ -131,14 +127,12 @@ class UsernameHintsPermissionTest(TestCase):
         self.create_account(asset, 'ssh-user')
         self.create_account(asset, 'telnet-only-user')
         self.grant(
-            'SSH upload permission',
             asset,
             'ssh-user',
             ActionChoices.upload.value,
             protocols=[Protocol.ssh],
         )
         self.grant(
-            'Telnet upload permission',
             asset,
             'telnet-only-user',
             ActionChoices.upload.value,
@@ -154,13 +148,11 @@ class UsernameHintsPermissionTest(TestCase):
         self.create_account(asset, 'connect-user')
         self.create_account(asset, 'upload-only-user')
         self.grant(
-            'Connect account permission',
             asset,
             'connect-user',
             ActionChoices.connect.value,
         )
         self.grant(
-            'Upload account permission',
             asset,
             'upload-only-user',
             ActionChoices.upload.value,
@@ -174,7 +166,6 @@ class UsernameHintsPermissionTest(TestCase):
         small_asset = self.create_asset('query-small')
         self.create_account(small_asset, 'small-user')
         self.grant(
-            'Small query permission',
             small_asset,
             'small-user',
             ActionChoices.upload.value,
@@ -186,7 +177,6 @@ class UsernameHintsPermissionTest(TestCase):
             username = f'large-user-{index}'
             self.create_account(asset, username)
             self.grant(
-                f'Large query permission {index}',
                 asset,
                 username,
                 ActionChoices.upload.value,
@@ -241,13 +231,11 @@ class UsernameHintsPermissionTest(TestCase):
         self.create_account(asset, 'allowed-user')
         self.create_account(asset, 'excluded-user')
         self.grant(
-            'All upload accounts',
             asset,
             '@ALL',
             ActionChoices.upload.value,
         )
         self.grant(
-            'Exclude upload account',
             asset,
             '!excluded-user',
             ActionChoices.upload.value,

--- a/apps/ops/tests/test_username_hints.py
+++ b/apps/ops/tests/test_username_hints.py
@@ -1,12 +1,14 @@
 from datetime import timedelta
 from types import SimpleNamespace
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from accounts.models import Account
 from assets.const import Category, HostTypes, Protocol
-from assets.models import Asset, Platform
+from assets.models import Asset, Node, Platform
 from ops.api.job import UsernameHintsAPI
 from orgs.models import Organization
 from orgs.utils import tmp_to_org, tmp_to_root_org
@@ -52,13 +54,13 @@ class UsernameHintsPermissionTest(TestCase):
                 username=username,
             )
 
-    def grant(self, name, asset, account, actions):
+    def grant(self, name, asset, account, actions, protocols=None):
         with tmp_to_root_org():
             permission = AssetPermission.objects.create(
                 org_id=self.org.id,
                 name=name,
                 accounts=[account],
-                protocols=list(
+                protocols=protocols or list(
                     asset.protocols.values_list('name', flat=True)
                 ),
                 actions=actions,
@@ -69,9 +71,10 @@ class UsernameHintsPermissionTest(TestCase):
             permission.assets.add(asset)
 
     def get_hints(self, asset, action=None):
+        assets = asset if isinstance(asset, list) else [asset]
         data = {
             'nodes': [],
-            'assets': [str(asset.id)],
+            'assets': [str(item.id) for item in assets],
             'query': '',
         }
         if action:
@@ -123,6 +126,29 @@ class UsernameHintsPermissionTest(TestCase):
 
         self.assertEqual(hints, [])
 
+    def test_upload_hints_filter_each_permission_by_protocol(self):
+        asset = self.create_asset('mixed-protocol-asset')
+        self.create_account(asset, 'ssh-user')
+        self.create_account(asset, 'telnet-only-user')
+        self.grant(
+            'SSH upload permission',
+            asset,
+            'ssh-user',
+            ActionChoices.upload.value,
+            protocols=[Protocol.ssh],
+        )
+        self.grant(
+            'Telnet upload permission',
+            asset,
+            'telnet-only-user',
+            ActionChoices.upload.value,
+            protocols=[Protocol.telnet],
+        )
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [{'username': 'ssh-user', 'total': 1}])
+
     def test_default_hints_keep_connect_permission_semantics(self):
         asset = self.create_asset('quick-job-asset')
         self.create_account(asset, 'connect-user')
@@ -143,3 +169,92 @@ class UsernameHintsPermissionTest(TestCase):
         hints = self.get_hints(asset)
 
         self.assertEqual(hints, [{'username': 'connect-user', 'total': 1}])
+
+    def test_query_count_does_not_grow_per_selected_asset(self):
+        small_asset = self.create_asset('query-small')
+        self.create_account(small_asset, 'small-user')
+        self.grant(
+            'Small query permission',
+            small_asset,
+            'small-user',
+            ActionChoices.upload.value,
+        )
+
+        large_assets = []
+        for index in range(8):
+            asset = self.create_asset(f'query-large-{index}')
+            username = f'large-user-{index}'
+            self.create_account(asset, username)
+            self.grant(
+                f'Large query permission {index}',
+                asset,
+                username,
+                ActionChoices.upload.value,
+            )
+            large_assets.append(asset)
+
+        def get_usernames(assets):
+            return UsernameHintsAPI.get_permed_account_usernames(
+                self.user,
+                assets,
+                ActionChoices.upload.value,
+                UsernameHintsAPI.upload_protocols,
+            )
+
+        with tmp_to_org(self.org):
+            with CaptureQueriesContext(connection) as small_queries:
+                get_usernames([small_asset])
+            with CaptureQueriesContext(connection) as large_queries:
+                get_usernames(large_assets)
+
+        self.assertLessEqual(len(large_queries), len(small_queries) + 2)
+        self.assertLessEqual(len(large_queries), 20)
+
+    def test_node_permission_is_applied_to_child_asset(self):
+        asset = self.create_asset('node-authorized-asset')
+        self.create_account(asset, 'node-upload-user')
+        with tmp_to_org(self.org):
+            node = Node.org_root().create_child('File transfer')
+            child = node.create_child('Linux')
+            asset.nodes.add(child)
+        with tmp_to_root_org():
+            permission = AssetPermission.objects.create(
+                org_id=self.org.id,
+                name='Node upload permission',
+                accounts=['node-upload-user'],
+                protocols=[Protocol.ssh],
+                actions=ActionChoices.upload.value,
+                date_start=timezone.now() - timedelta(minutes=1),
+                date_expired=timezone.now() + timedelta(days=1),
+            )
+            permission.users.add(self.user)
+            permission.nodes.add(node)
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [
+            {'username': 'node-upload-user', 'total': 1},
+        ])
+
+    def test_all_account_alias_honors_explicit_exclusion(self):
+        asset = self.create_asset('all-account-asset')
+        self.create_account(asset, 'allowed-user')
+        self.create_account(asset, 'excluded-user')
+        self.grant(
+            'All upload accounts',
+            asset,
+            '@ALL',
+            ActionChoices.upload.value,
+        )
+        self.grant(
+            'Exclude upload account',
+            asset,
+            '!excluded-user',
+            ActionChoices.upload.value,
+        )
+
+        hints = self.get_hints(asset, action='upload')
+
+        self.assertEqual(hints, [
+            {'username': 'allowed-user', 'total': 1},
+        ])

--- a/apps/perms/utils/asset_perm.py
+++ b/apps/perms/utils/asset_perm.py
@@ -1,16 +1,242 @@
 from collections import defaultdict
 
 from accounts.const import AliasAccount
-from accounts.models import VirtualAccount
-from assets.models import Asset, MyAsset
+from accounts.models import Account, VirtualAccount
+from assets.models import Asset, MyAsset, Node, Protocol
 from common.utils import lazyproperty, get_logger
 from orgs.utils import tmp_to_org, tmp_to_root_org
 from perms.const import ActionChoices
+from perms.models import AssetPermission
 from .permission import AssetPermissionUtil
 
 logger = get_logger(__name__)
 
-__all__ = ['PermAssetDetailUtil']
+__all__ = ['PermAssetAccountsBatchUtil', 'PermAssetDetailUtil']
+
+
+class PermAssetAccountsBatchUtil:
+    """Resolve a user's permitted real accounts for multiple assets in bulk."""
+
+    def __init__(self, user):
+        self.user = user
+
+    @staticmethod
+    def permission_matches_protocol(permission, protocols):
+        permitted = set(permission.protocols or [])
+        return 'all' in permitted or bool(permitted.intersection(protocols))
+
+    @staticmethod
+    def get_node_ancestor_keys(key):
+        parts = key.split(':')
+        return {
+            ':'.join(parts[:index])
+            for index in range(1, len(parts) + 1)
+        }
+
+    def get_asset_permission_ids(self, asset_ids, permission_ids):
+        asset_permission_ids = defaultdict(set)
+        direct_relations = AssetPermission.assets.through.objects.filter(
+            asset_id__in=asset_ids,
+            assetpermission_id__in=permission_ids,
+        ).values_list('asset_id', 'assetpermission_id')
+        for asset_id, permission_id in direct_relations:
+            asset_permission_ids[asset_id].add(permission_id)
+
+        asset_node_relations = list(
+            Asset.nodes.through.objects.filter(
+                asset_id__in=asset_ids,
+            ).values_list('asset_id', 'node__key')
+        )
+        assets_with_nodes = {
+            asset_id for asset_id, _key in asset_node_relations
+        }
+        assets_without_nodes = set(asset_ids) - assets_with_nodes
+        if assets_without_nodes:
+            root_key = Node.org_root().key
+            if root_key:
+                asset_node_relations.extend(
+                    (asset_id, root_key) for asset_id in assets_without_nodes
+                )
+
+        ancestor_assets = defaultdict(set)
+        for asset_id, node_key in asset_node_relations:
+            for ancestor_key in self.get_node_ancestor_keys(node_key):
+                ancestor_assets[ancestor_key].add(asset_id)
+
+        ancestor_keys = set(ancestor_assets)
+        if not ancestor_keys:
+            return asset_permission_ids
+        permission_node_relations = (
+            AssetPermission.nodes.through.objects.filter(
+                assetpermission_id__in=permission_ids,
+                node__key__in=ancestor_keys,
+            ).values_list('assetpermission_id', 'node__key')
+        )
+        for permission_id, node_key in permission_node_relations:
+            for asset_id in ancestor_assets.get(node_key, set()):
+                asset_permission_ids[asset_id].add(permission_id)
+        return asset_permission_ids
+
+    @staticmethod
+    def get_asset_protocols(asset_ids):
+        asset_protocols = defaultdict(set)
+        relations = Protocol.objects.filter(
+            asset_id__in=asset_ids,
+        ).values_list('asset_id', 'name')
+        for asset_id, protocol in relations:
+            asset_protocols[asset_id].add(protocol)
+        return asset_protocols
+
+    @staticmethod
+    def get_asset_account_usernames(asset_ids):
+        source_asset_ids = set(asset_ids)
+        source_targets = defaultdict(set)
+        for asset_id in asset_ids:
+            source_targets[asset_id].add(asset_id)
+
+        directory_relations = (
+            Asset.directory_services.through.objects.filter(
+                asset_id__in=asset_ids,
+            ).values_list('asset_id', 'directoryservice_id')
+        )
+        for asset_id, directory_service_id in directory_relations:
+            source_asset_ids.add(directory_service_id)
+            source_targets[directory_service_id].add(asset_id)
+
+        asset_usernames = defaultdict(list)
+        accounts = Account.objects.filter(
+            asset_id__in=source_asset_ids,
+            is_active=True,
+        ).values_list('asset_id', 'username')
+        for source_asset_id, username in accounts:
+            for target_asset_id in source_targets[source_asset_id]:
+                asset_usernames[target_asset_id].append(username)
+        return asset_usernames
+
+    @staticmethod
+    def get_alias_actions(permissions):
+        alias_actions = defaultdict(int)
+        for permission in permissions:
+            for alias in permission.accounts:
+                alias_actions[alias] |= permission.actions
+        return alias_actions
+
+    @staticmethod
+    def expand_all_alias(alias_actions, account_usernames):
+        all_actions = alias_actions.pop(AliasAccount.ALL, 0)
+        if not all_actions:
+            return
+        for username in account_usernames:
+            alias_actions[username] |= all_actions
+
+    @staticmethod
+    def apply_exclusions(alias_actions):
+        exclusions = {
+            alias: actions
+            for alias, actions in alias_actions.items()
+            if alias.startswith('!')
+        }
+        for alias, actions in exclusions.items():
+            alias_actions.pop(alias, None)
+            alias_actions[alias.lstrip('!')] &= ~actions
+
+    def resolve_alias_actions(self, alias_actions, account_usernames):
+        resolved_actions = defaultdict(int)
+        for alias, actions in alias_actions.items():
+            if actions <= 0:
+                continue
+            if alias == AliasAccount.USER:
+                username = self.user.username
+            elif alias.startswith('@'):
+                continue
+            else:
+                username = alias
+            if username in account_usernames:
+                resolved_actions[username] |= actions
+        return resolved_actions
+
+    def get_asset_permitted_usernames(
+        self, asset_id, permission_ids, permissions_by_id,
+        asset_protocols, asset_usernames, required_protocols,
+        action_required,
+    ):
+        actual_protocols = asset_protocols.get(asset_id, set())
+        protocols = (
+            actual_protocols.intersection(required_protocols)
+            if required_protocols else actual_protocols
+        )
+        if not protocols:
+            return []
+
+        permissions = (
+            permissions_by_id[permission_id]
+            for permission_id in permission_ids
+            if self.permission_matches_protocol(
+                permissions_by_id[permission_id], protocols,
+            )
+        )
+        account_usernames = asset_usernames.get(asset_id, [])
+        account_username_set = set(account_usernames)
+        alias_actions = self.get_alias_actions(permissions)
+        self.expand_all_alias(alias_actions, account_username_set)
+        self.apply_exclusions(alias_actions)
+        resolved_actions = self.resolve_alias_actions(
+            alias_actions, account_username_set,
+        )
+
+        return [
+            username for username in account_usernames
+            if not username.startswith(('jms_', 'js_'))
+            and ActionChoices.contains(
+                resolved_actions.get(username, 0), action_required,
+            )
+        ]
+
+    def get_permitted_account_usernames(
+        self, assets, action_required, protocols_required=None,
+    ):
+        asset_ids = [asset.id for asset in assets]
+        if not asset_ids:
+            return []
+
+        permissions = list(
+            AssetPermissionUtil().get_permissions_for_user(self.user).only(
+                'id', 'accounts', 'protocols', 'actions',
+            )
+        )
+        permissions_by_id = {
+            permission.id: permission for permission in permissions
+        }
+        permission_ids = list(permissions_by_id)
+        if not permission_ids:
+            return []
+
+        asset_permission_ids = self.get_asset_permission_ids(
+            asset_ids, permission_ids,
+        )
+        asset_ids = [
+            asset_id for asset_id in asset_ids
+            if asset_permission_ids.get(asset_id)
+        ]
+        if not asset_ids:
+            return []
+
+        asset_protocols = self.get_asset_protocols(asset_ids)
+        asset_usernames = self.get_asset_account_usernames(asset_ids)
+        required_protocols = set(protocols_required or [])
+
+        usernames = []
+        for asset_id in asset_ids:
+            usernames.extend(self.get_asset_permitted_usernames(
+                asset_id,
+                asset_permission_ids[asset_id],
+                permissions_by_id,
+                asset_protocols,
+                asset_usernames,
+                required_protocols,
+                action_required,
+            ))
+        return usernames
 
 
 class PermAssetDetailUtil:

--- a/apps/perms/utils/asset_perm.py
+++ b/apps/perms/utils/asset_perm.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from dataclasses import dataclass
 
 from accounts.const import AliasAccount
 from accounts.models import Account, VirtualAccount
@@ -14,10 +15,22 @@ logger = get_logger(__name__)
 __all__ = ['PermAssetAccountsBatchUtil', 'PermAssetDetailUtil']
 
 
+@dataclass(frozen=True)
+class PermAssetAccountsBatchContext:
+    """Input data shared while resolving permitted accounts for assets."""
+
+    permissions_by_id: dict
+    asset_protocols: dict
+    asset_usernames: dict
+    required_protocols: set
+    action_required: int
+
+
 class PermAssetAccountsBatchUtil:
     """Resolve a user's permitted real accounts for multiple assets in bulk."""
 
     def __init__(self, user):
+        """Initialize the resolver for a user."""
         self.user = user
 
     @staticmethod
@@ -42,21 +55,7 @@ class PermAssetAccountsBatchUtil:
         for asset_id, permission_id in direct_relations:
             asset_permission_ids[asset_id].add(permission_id)
 
-        asset_node_relations = list(
-            Asset.nodes.through.objects.filter(
-                asset_id__in=asset_ids,
-            ).values_list('asset_id', 'node__key')
-        )
-        assets_with_nodes = {
-            asset_id for asset_id, _key in asset_node_relations
-        }
-        assets_without_nodes = set(asset_ids) - assets_with_nodes
-        if assets_without_nodes:
-            root_key = Node.org_root().key
-            if root_key:
-                asset_node_relations.extend(
-                    (asset_id, root_key) for asset_id in assets_without_nodes
-                )
+        asset_node_relations = self.get_asset_node_relations(asset_ids)
 
         ancestor_assets = defaultdict(set)
         for asset_id, node_key in asset_node_relations:
@@ -76,6 +75,25 @@ class PermAssetAccountsBatchUtil:
             for asset_id in ancestor_assets.get(node_key, set()):
                 asset_permission_ids[asset_id].add(permission_id)
         return asset_permission_ids
+
+    @staticmethod
+    def get_asset_node_relations(asset_ids):
+        asset_node_relations = list(
+            Asset.nodes.through.objects.filter(
+                asset_id__in=asset_ids,
+            ).values_list('asset_id', 'node__key')
+        )
+        assets_with_nodes = {
+            asset_id for asset_id, _key in asset_node_relations
+        }
+        assets_without_nodes = set(asset_ids) - assets_with_nodes
+        if assets_without_nodes:
+            root_key = Node.org_root().key
+            if root_key:
+                asset_node_relations.extend(
+                    (asset_id, root_key) for asset_id in assets_without_nodes
+                )
+        return asset_node_relations
 
     @staticmethod
     def get_asset_protocols(asset_ids):
@@ -156,26 +174,24 @@ class PermAssetAccountsBatchUtil:
         return resolved_actions
 
     def get_asset_permitted_usernames(
-        self, asset_id, permission_ids, permissions_by_id,
-        asset_protocols, asset_usernames, required_protocols,
-        action_required,
+        self, asset_id, permission_ids, context,
     ):
-        actual_protocols = asset_protocols.get(asset_id, set())
+        actual_protocols = context.asset_protocols.get(asset_id, set())
         protocols = (
-            actual_protocols.intersection(required_protocols)
-            if required_protocols else actual_protocols
+            actual_protocols.intersection(context.required_protocols)
+            if context.required_protocols else actual_protocols
         )
         if not protocols:
             return []
 
         permissions = (
-            permissions_by_id[permission_id]
+            context.permissions_by_id[permission_id]
             for permission_id in permission_ids
             if self.permission_matches_protocol(
-                permissions_by_id[permission_id], protocols,
+                context.permissions_by_id[permission_id], protocols,
             )
         )
-        account_usernames = asset_usernames.get(asset_id, [])
+        account_usernames = context.asset_usernames.get(asset_id, [])
         account_username_set = set(account_usernames)
         alias_actions = self.get_alias_actions(permissions)
         self.expand_all_alias(alias_actions, account_username_set)
@@ -188,7 +204,7 @@ class PermAssetAccountsBatchUtil:
             username for username in account_usernames
             if not username.startswith(('jms_', 'js_'))
             and ActionChoices.contains(
-                resolved_actions.get(username, 0), action_required,
+                resolved_actions.get(username, 0), context.action_required,
             )
         ]
 
@@ -221,20 +237,20 @@ class PermAssetAccountsBatchUtil:
         if not asset_ids:
             return []
 
-        asset_protocols = self.get_asset_protocols(asset_ids)
-        asset_usernames = self.get_asset_account_usernames(asset_ids)
-        required_protocols = set(protocols_required or [])
+        context = PermAssetAccountsBatchContext(
+            permissions_by_id=permissions_by_id,
+            asset_protocols=self.get_asset_protocols(asset_ids),
+            asset_usernames=self.get_asset_account_usernames(asset_ids),
+            required_protocols=set(protocols_required or []),
+            action_required=action_required,
+        )
 
         usernames = []
         for asset_id in asset_ids:
             usernames.extend(self.get_asset_permitted_usernames(
                 asset_id,
                 asset_permission_ids[asset_id],
-                permissions_by_id,
-                asset_protocols,
-                asset_usernames,
-                required_protocols,
-                action_required,
+                context,
             ))
         return usernames
 


### PR DESCRIPTION
#### Problem

On Operations > File Transfer and Quick Jobs, the account username autocomplete could suggest accounts the user was not authorized to use. These usernames were later rejected when the operation was executed.

#### Cause

The username-hints endpoint filtered the selected assets, but then queried every account attached to those assets instead of resolving the request user's effective account permissions, required action, and available protocols.

#### Fix

- Resolve username hints from effective asset and account permissions.
- Use `connect` as the default action and support `action: upload` for file transfers.
- Batch permission and account lookups to avoid N+1 queries.
- Exclude virtual and internal JumpServer accounts.

Companion UI change: jumpserver/lina#5597

#### Verification

- 7 username-hint permission tests passed.
- Query growth, node permissions, protocol filtering, and account exclusions are covered.
- Django system check, Codacy, and SonarCloud passed.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit messages follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact; no documentation change is required.