### PR TITLE
fix: optimize celery task log terminal resize reflow and scrollbar

### DIFF
--- a/apps/ops/templates/ops/celery_task_log.html
+++ b/apps/ops/templates/ops/celery_task_log.html
@@ -168,6 +168,9 @@
             min-width: 0;
             min-height: 0;
             flex: 1 1 auto;
+            /* Reserve a track for the custom scrollbar so terminal content never
+               extends underneath it (the fit addon does not subtract the padding) */
+            padding-right: 16px;
             background: #0d1117;
             overflow: hidden;
         }
@@ -433,10 +436,169 @@
 
         connectLog('celery');
         getAutomationExecutionInfo();
-    }).on('resize', window, function () {
-        window.fit.fit(term);
-        scheduleTerminalScrollbarUpdate();
     });
+
+    var terminalResizeTimer = null;
+    function handleTerminalResize() {
+        window.clearTimeout(terminalResizeTimer);
+        terminalResizeTimer = window.setTimeout(function () {
+            if (!term || !term._core) {
+                return;
+            }
+            var prevCols = term._core.cols;
+            window.fit.fit(term);
+            // The bundled xterm.js cannot reflow existing buffer lines by itself,
+            // rebuild them here so already-printed text re-wraps to the new width.
+            if (term._core.cols !== prevCols) {
+                reflowTerminalBuffer();
+            }
+            scheduleTerminalScrollbarUpdate();
+        }, 80);
+    }
+
+    // The bundled xterm.js does not reflow the scrollback on resize: its
+    // Buffer#resize only pads existing lines with spaces, so after enlarging the
+    // window the .xterm-screen grows but already-displayed text keeps wrapping at
+    // the old width. This rebuilds the buffer from its own cell data so the text
+    // re-wraps to the new column count, keeping colors and approximate scroll pos.
+    function reflowTerminalBuffer() {
+        try {
+            var core = term._core;
+            var buffer = core.buffer;
+            var lines = buffer.lines;
+            var cols = core.cols;
+            var rows = core.rows;
+            if (!lines || lines.length === 0 || cols < 1 || rows < 1) {
+                return;
+            }
+
+            // 1) Flatten the physical lines into logical lines (join wrapped runs)
+            var logical = [];
+            var current = [];
+            var i, line, end, segment;
+            for (i = 0; i < lines.length; i++) {
+                line = lines.get(i);
+                end = line.length;
+                while (end > 0 && line[end - 1][2] === 1 && line[end - 1][3] === 32) {
+                    end--;
+                }
+                segment = line.slice(0, end);
+                if (line.isWrapped) {
+                    current = current.concat(segment);
+                } else {
+                    if (i > 0) {
+                        logical.push(current);
+                    }
+                    current = segment;
+                }
+            }
+            logical.push(current);
+
+            // 2) Re-split every logical line at the new column count
+            var blank = core.blankLine(false, false, cols);
+            var blankCell = blank[0];
+            var rebuilt = [];
+            var cursorIndex = -1;
+            var cursorX = 0;
+            var lastLogicalIndex = logical.length - 1;
+            for (i = 0; i < logical.length; i++) {
+                var l = logical[i];
+                if (l.length === 0) {
+                    rebuilt.push(blank.slice());
+                    if (i === lastLogicalIndex) {
+                        cursorIndex = rebuilt.length - 1;
+                        cursorX = 0;
+                    }
+                    continue;
+                }
+                var chunks = Math.ceil(l.length / cols);
+                for (var c = 0; c < chunks; c++) {
+                    var chunk = l.slice(c * cols, Math.min((c + 1) * cols, l.length));
+                    if (c > 0) {
+                        chunk.isWrapped = true;
+                    }
+                    while (chunk.length < cols) {
+                        chunk.push(blankCell);
+                    }
+                    rebuilt.push(chunk);
+                    if (i === lastLogicalIndex && c === chunks - 1) {
+                        cursorIndex = rebuilt.length - 1;
+                        cursorX = l.length % cols;
+                    }
+                }
+            }
+            // If the last logical line ends exactly at a column boundary, the
+            // cursor continues on a new line instead of overwriting column 0.
+            var lastLen = logical[lastLogicalIndex].length;
+            if (cursorIndex >= 0 && cursorX === 0 && lastLen > 0 && lastLen % cols === 0) {
+                rebuilt.push(blank.slice());
+                cursorIndex = rebuilt.length - 1;
+            }
+
+            // 3) Always keep the viewport (rows) filled
+            while (rebuilt.length < rows) {
+                rebuilt.push(blank.slice());
+            }
+
+            // 4) Swap the lines in place so all internal references stay valid
+            var oldLength = lines.length;
+            var oldYdisp = buffer.ydisp;
+            var total = rebuilt.length;
+            if (lines.maxLength < total) {
+                lines.maxLength = total;
+            }
+            lines.length = 0;
+            for (i = 0; i < total; i++) {
+                lines.push(rebuilt[i]);
+            }
+
+            // 5) Recompute scroll/cursor state
+            buffer.ybase = Math.max(0, total - rows);
+            var distanceFromBottom = Math.max(0, oldLength - 1 - oldYdisp);
+            buffer.ydisp = Math.max(0, total - 1 - distanceFromBottom);
+            if (buffer.ydisp > buffer.ybase) {
+                buffer.ydisp = buffer.ybase;
+            }
+            buffer.y = cursorIndex >= 0
+                ? cursorIndex - buffer.ybase
+                : total - 1 - buffer.ybase;
+            if (buffer.y < 0) {
+                buffer.y = 0;
+            } else if (buffer.y > rows - 1) {
+                buffer.y = rows - 1;
+            }
+            buffer.x = cursorX < 0 ? 0 : Math.min(cols - 1, cursorX);
+            buffer.scrollTop = 0;
+            buffer.scrollBottom = rows - 1;
+
+            // 6) Force a full re-render and resync the scroll area
+            if (core.renderer) {
+                core.renderer.clear();
+            }
+            if (core.clearSelection) {
+                core.clearSelection();
+            }
+            core.refresh(0, rows - 1);
+            if (core.viewport && core.viewport.syncScrollArea) {
+                core.viewport.syncScrollArea();
+            }
+        } catch (e) {
+            // Never break the log view if the reflow hits an unexpected state.
+        }
+    }
+
+    // Bind the resize handler to `window` directly. The previous
+    // `.on('resize', window, ...)` treated `window` as event data (it's not a
+    // selector string) and attached the handler to `document`, where the
+    // native `resize` event never bubbles to, so fit() was never re-run.
+    $(window).on('resize', handleTerminalResize);
+
+    // Also observe the terminal container so the size follows viewport
+    // changes that do not fire a window resize (DevTools, zoom, iframe, ...)
+    var termElement = document.getElementById('term');
+    if (window.ResizeObserver && termElement) {
+        new ResizeObserver(handleTerminalResize).observe(termElement);
+    }
 
     function setupTerminalScrollbar() {
         terminalViewport = document.querySelector('#term .xterm-viewport');


### PR DESCRIPTION
#### What this PR does / why we need it?

运维任务日志页（celery_task_log.html）使用内置 xterm.js 渲染 Celery/Ansible 任务日志，存在三个问题：

- 窗口缩放时终端尺寸不跟随：原 resize 监听写成 .on('resize', window, ...)，jQuery 会把非字符串的 window 当作事件数据，处理器实际绑定到 document；而浏览器的 resize 事件只在 window 上触发、不会冒泡到 document，导致 fit() 从未被重新调用，终端行列数不随窗口变化。
- 已显示文本不按新宽度换行：内置 xterm.js 的 Buffer#resize 只给行尾补空格，不做 scrollback 重排。窗口放大后 .xterm-screen 变宽、列数增加，但已经打印的内容仍按旧宽度换行，右侧留白。
- 滚动条盖住字符：fit 计算列数时未扣除 #term 自身的左右内边距，xterm-screen 比内容区宽约 24px，右端延伸到自定义滚动条区域，日志溢出出现滚动条时最后 1~2 列字符被遮挡。

#### Summary of your change

- 修复 resize 监听：改为 $(window).on('resize', handleTerminalResize) 直接绑定 window，并加入 80ms 防抖；同时新增 ResizeObserver 监听 #term 容器，覆盖 DevTools 展开、浏览器缩放、iframe 内嵌等不触发 window resize 的场景。
- 新增 reflowTerminalBuffer() 手动重排：在列数真正变化时，基于缓冲区单元格数据重建所有行，按新列数重新折行（拼接 isWrapped 的续行、裁剪行尾空格、保留单元格属性/颜色），并近似保留滚动位置与光标位置；整体用 try/catch 包裹，异常时静默回退，不影响页面正常显示。
- 为自定义滚动条预留轨道：.terminal-body 增加 padding-right: 16px，使终端内容右边缘始终停在滚动条左侧，避免字符被遮挡；同时滚动条显示/隐藏时终端宽度恒定，文本不会来回跳动。

#### How to test

- 打开任务日志页，放大/缩小窗口，确认终端行列数随容器变化，已显示文本按新宽度重新折行。
- 日志内容溢出出现滚动条时，确认最后一列字符完整显示、不被滚动条遮挡。
- 回归验证：滚动条拖动/点击轨道、切换 Celery/Ansible 日志、下载日志等功能正常。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.