### PR TITLE
fix: use discoverable credentials for Passkey MFA confirm

### DIFF
--- a/apps/authentication/backends/passkey/api.py
+++ b/apps/authentication/backends/passkey/api.py
@@ -58,8 +58,9 @@ class PasskeyViewSet(AuthMixin, FlashMessageMixin, JMSModelViewSet):
 
     @action(methods=['get', 'post'], detail=False, url_path='auth', permission_classes=[AllowAny])
     def auth(self, request):
+        confirm_mfa = request.session.get('passkey_confirm_mfa')
         if request.method == 'GET':
-            auth_data = auth_begin(request)
+            auth_data = auth_begin(request, discoverable=bool(confirm_mfa))
             return JsonResponse(dict(auth_data))
 
         try:
@@ -70,9 +71,10 @@ class PasskeyViewSet(AuthMixin, FlashMessageMixin, JMSModelViewSet):
         if not user:
             return self.redirect_to_error(_('Auth failed'))
 
-        confirm_mfa = request.session.get('passkey_confirm_mfa')
         # 如果开启了安全模式，Passkey 不能作为 MFA
         if confirm_mfa and not settings.SAFE_MODE:
+            if not request.user.is_authenticated or user != request.user:
+                return self.redirect_to_error(_('Auth failed'))
             request.session['CONFIRM_LEVEL'] = ConfirmType.values.index('mfa') + 1
             request.session['CONFIRM_TIME'] = int(time.time())
             request.session['CONFIRM_TYPE'] = ConfirmType.MFA

--- a/apps/authentication/backends/passkey/fido.py
+++ b/apps/authentication/backends/passkey/fido.py
@@ -126,15 +126,14 @@ def register_complete(request):
     return passkey
 
 
-def auth_begin(request):
+def auth_begin(request, discoverable=False):
     server = get_server(request)
     credentials = []
 
-    username = None
-    if request.user.is_authenticated:
-        username = request.user.username
-    if username:
-        credentials = get_user_credentials(username)
+    # Discoverable credentials (empty allowCredentials) are required for some
+    # platform authenticators (e.g. Windows Password Manager) during MFA confirm.
+    if not discoverable and request.user.is_authenticated:
+        credentials = get_user_credentials(request.user.username)
     auth_data, state = server.authenticate_begin(credentials)
     request.session['fido2_state'] = state
     return auth_data

--- a/apps/authentication/templates/authentication/passkey.html
+++ b/apps/authentication/templates/authentication/passkey.html
@@ -120,7 +120,8 @@
     function GetAssertReq(getAssert) {
         getAssert.publicKey.challenge = decode(getAssert.publicKey.challenge)
 
-        for (const allowCred of getAssert.publicKey.allowCredentials) {
+        const allowCredentials = getAssert.publicKey.allowCredentials || []
+        for (const allowCred of allowCredentials) {
             allowCred.id = decode(allowCred.id)
         }
         return getAssert


### PR DESCRIPTION
## 问题背景

修复 [#17234](https://github.com/jumpserver/jumpserver/issues/17234)：使用 **Windows Password Manager** 保存的 Passkey，登录可以成功，但查看账号密码做 MFA 二次确认时失败。

根因是两条路径对 WebAuthn `allowCredentials` 的处理不一致：

| 场景 | 用户状态 | `allowCredentials` | Windows Password Manager |
|------|----------|----------------------|--------------------------|
| 登录 | 未登录 | 空（可发现凭证） | 正常 |
| 查看密码 MFA | 已登录 | 填了当前用户的 credential id | 失败 |

Mac 指纹、Bitwarden、「此 Windows 设备」不受影响，仅 Windows Password Manager 对「非空 allowCredentials」兼容性差。

## 改动说明

1. **MFA 确认走可发现凭证**：`auth_begin(..., discoverable=True)`，与登录一样不填充 `allowCredentials`
2. **归属校验**：空列表后用户可能选到别人的钥匙，校验断言得到的 Passkey 必须属于当前登录用户
3. **前端兼容**：`allowCredentials` 缺失或为空时不再抛错；空数组时删除该字段，走 discoverable 流程
4. **会话清理**：MFA 成功后 `pop` 掉 `passkey_confirm_mfa`，避免脏标记

## 改完效果

- Windows Password Manager Passkey：登录、查看账号密码 MFA 均可成功
- 其他 Passkey（Mac / Bitwarden / 此 Windows 设备）行为不变
- MFA 场景不会误用其他用户的 Passkey 完成确认

## Checklist

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Fixes #17234