### PR TITLE
fix: misleading DOMAINS hint on login when CSRF cookie not set

### DIFF
--- a/apps/authentication/templates/authentication/login.html
+++ b/apps/authentication/templates/authentication/login.html
@@ -314,6 +314,14 @@
         DOMAINS={{ error_origin }}
     </div>
 {% endif %}
+{% if csrf_cookie_error %}
+    <div class='alert alert-danger error-info'>
+        {% trans 'The browser did not carry the CSRF cookie and cannot be logged in. Please contact the administrator' %}<br/>
+        {% trans 'If you are administrator, check whether SESSION_COOKIE_DOMAIN is misconfigured: the domain you are accessing must be it or its subdomain, otherwise the browser will not save the cookie, fix or remove it' %} <br/>
+        SESSION_COOKIE_DOMAIN={% if session_cookie_domain %}{{ session_cookie_domain }}{% else %}{% trans 'not set' %}{% endif %}<br/>
+        {% trans 'Please make sure cookies are enabled in your browser, clear the site cookies and try again' %}
+    </div>
+{% endif %}
 <div class="login-content extra-fields-{{ extra_fields_count }}">
     <div class="right-image-box">
         <a href="{% if not XPACK_ENABLED %}https://github.com/jumpserver/jumpserver.git{% endif %}">

--- a/apps/authentication/views/login.py
+++ b/apps/authentication/views/login.py
@@ -98,6 +98,11 @@ class UserLoginContextMixin:
         if not self.request.GET.get('csrf_failure'):
             return context
 
+        if self.request.GET.get('csrf_reason') == 'cookie':
+            context['csrf_cookie_error'] = True
+            context['session_cookie_domain'] = settings.SESSION_COOKIE_DOMAIN
+            return context
+
         http_origin = self.request.META.get('HTTP_ORIGIN')
         http_referer = self.request.META.get('HTTP_REFERER')
         http_origin = http_origin or http_referer

--- a/apps/i18n/core/en/LC_MESSAGES/django.po
+++ b/apps/i18n/core/en/LC_MESSAGES/django.po
@@ -6040,6 +6040,36 @@ msgstr ""
 "If you are an administrator, you can resolve this by updating the "
 "configuration file and setting the configuration item"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "not set"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "Or"

--- a/apps/i18n/core/es/LC_MESSAGES/django.po
+++ b/apps/i18n/core/es/LC_MESSAGES/django.po
@@ -6147,6 +6147,37 @@ msgstr ""
 "Si eres el administrador, puedes actualizar el perfil para solucionarlo, "
 "estableciendo los parámetros de configuración."
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr ""
+"El navegador no envió la cookie CSRF y no se puede iniciar sesión. Por "
+"favor, contacte al administrador"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"Si es administrador, compruebe si SESSION_COOKIE_DOMAIN está mal "
+"configurado: el dominio al que accede debe ser este o un subdominio suyo, de "
+"lo contrario el navegador no guardará la cookie; corrija o elimine esta "
+"configuración"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "sin configurar"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr ""
+"Asegúrese de que las cookies estén habilitadas en su navegador, borre las "
+"cookies del sitio e inténtelo de nuevo"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "Otras formas de iniciar sesión"

--- a/apps/i18n/core/ja/LC_MESSAGES/django.po
+++ b/apps/i18n/core/ja/LC_MESSAGES/django.po
@@ -5886,6 +5886,32 @@ msgstr "設定ファイルに問題があり、ログインできません。管
 msgid "If you are administrator, you can update the config resolve it, set"
 msgstr "管理者の場合は、configを更新して解決することができます。"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr "ブラウザが CSRF Cookie を送信していないため、ログインできません。管理者にお問い合わせください"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"管理者の場合は、SESSION_COOKIE_DOMAIN "
+"の設定に誤りがないか確認してください。アクセスに使用するドメインはその値またはそのサブドメインである必要があり、そうでない場合ブラウザは Cookie "
+"を保存しません。設定を修正するか削除してください"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "未設定"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr "ブラウザで Cookie が有効になっていることを確認し、サイトの Cookie を削除してから再試行してください"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "その他のログインオプション"

--- a/apps/i18n/core/ko/LC_MESSAGES/django.po
+++ b/apps/i18n/core/ko/LC_MESSAGES/django.po
@@ -5878,6 +5878,31 @@ msgstr "당신이 관리자라면, 설정 항목을 업데이트하여 문제를
 msgid "If you are administrator, you can update the config resolve it, set"
 msgstr "다른 통로로 로그인"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr "브라우저가 CSRF 쿠키를 전송하지 않아 로그인할 수 없습니다. 관리자에게 문의하세요"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"관리자인 경우 SESSION_COOKIE_DOMAIN 설정이 잘못되었는지 확인하세요. 접속 도메인은 해당 값 또는 그 하위 도메인이어야 "
+"하며, 그렇지 않으면 브라우저가 쿠키를 저장하지 않습니다. 설정을 수정하거나 삭제하세요"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "설정되지 않음"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr "브라우저에서 쿠키가 활성화되어 있는지 확인하고 사이트 쿠키를 삭제한 후 다시 시도하세요"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "기타 로그인 방법"

--- a/apps/i18n/core/pt_BR/LC_MESSAGES/django.po
+++ b/apps/i18n/core/pt_BR/LC_MESSAGES/django.po
@@ -6104,6 +6104,37 @@ msgstr ""
 "Se você é um administrador, pode resolver atualizando o arquivo de "
 "configuração, definindo itens de configuração"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr ""
+"O navegador não enviou o cookie CSRF e não é possível fazer login. Entre em "
+"contato com o administrador"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"Se você for administrador, verifique se SESSION_COOKIE_DOMAIN está "
+"configurado incorretamente: o domínio que você está acessando deve ser ele "
+"ou um subdomínio dele, caso contrário o navegador não salvará o cookie; "
+"corrija ou remova essa configuração"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "não configurado"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr ""
+"Verifique se os cookies estão habilitados no navegador, limpe os cookies do "
+"site e tente novamente"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "Login por outros métodos"

--- a/apps/i18n/core/ru/LC_MESSAGES/django.po
+++ b/apps/i18n/core/ru/LC_MESSAGES/django.po
@@ -6086,6 +6086,37 @@ msgstr ""
 "Если вы администратор, вы можете обновить конфигурационный файл для решения "
 "проблемы, настроив параметры."
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr ""
+"Браузер не передал CSRF cookie, вход невозможен. Пожалуйста, обратитесь к "
+"администратору"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"Если вы администратор, проверьте, не настроен ли SESSION_COOKIE_DOMAIN "
+"неправильно: домен, по которому вы обращаетесь, должен совпадать с ним или "
+"быть его поддоменом, иначе браузер не сохранит cookie; исправьте или удалите "
+"эту настройку"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "не задано"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr ""
+"Убедитесь, что в браузере включены cookie, очистите cookie сайта и "
+"попробуйте снова"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "Другие способы входа"

--- a/apps/i18n/core/vi/LC_MESSAGES/django.po
+++ b/apps/i18n/core/vi/LC_MESSAGES/django.po
@@ -6114,6 +6114,36 @@ msgstr ""
 "Nếu bạn là quản trị viên, bạn có thể cập nhật tệp cấu hình để giải quyết, "
 "thiết lập thông số cấu hình"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr ""
+"Trình duyệt không gửi CSRF cookie nên không thể đăng nhập. Vui lòng liên hệ "
+"quản trị viên"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"Nếu bạn là quản trị viên, hãy kiểm tra xem SESSION_COOKIE_DOMAIN có bị cấu "
+"hình sai không: tên miền bạn đang truy cập phải là nó hoặc tên miền con của "
+"nó, nếu không trình duyệt sẽ không lưu cookie; hãy sửa hoặc xóa cấu hình này"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "chưa được cấu hình"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr ""
+"Vui lòng đảm bảo cookie đã được bật trong trình duyệt, xóa cookie của trang "
+"web và thử lại"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "Or"

--- a/apps/i18n/core/zh/LC_MESSAGES/django.po
+++ b/apps/i18n/core/zh/LC_MESSAGES/django.po
@@ -5976,6 +5976,31 @@ msgstr ""
 msgid "If you are administrator, you can update the config resolve it, set"
 msgstr "如果你是管理员，可以更新配置文件解决，设置配置项"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr "浏览器未携带 CSRF Cookie，无法登录。请联系管理员"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"如果你是管理员，请检查 SESSION_COOKIE_DOMAIN 配置是否错误：访问域名必须是它或它的子域，否则浏览器不会保存 "
+"Cookie，请修正或删除该配置"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "未配置"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr "请确认浏览器已启用 Cookie，并清除本站 Cookie 后重试"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "更多登录方式"

--- a/apps/i18n/core/zh_Hant/LC_MESSAGES/django.po
+++ b/apps/i18n/core/zh_Hant/LC_MESSAGES/django.po
@@ -5859,6 +5859,31 @@ msgstr "配置文件有問題，無法登錄，請聯絡管理員或查看最新
 msgid "If you are administrator, you can update the config resolve it, set"
 msgstr "如果你是管理員，可以更新配置文件解決，設置配置項"
 
+#: authentication/templates/authentication/login.html:319
+msgid ""
+"The browser did not carry the CSRF cookie and cannot be logged in. Please "
+"contact the administrator"
+msgstr "瀏覽器未攜帶 CSRF Cookie，無法登入。請聯絡管理員"
+
+#: authentication/templates/authentication/login.html:320
+msgid ""
+"If you are administrator, check whether SESSION_COOKIE_DOMAIN is "
+"misconfigured: the domain you are accessing must be it or its subdomain, "
+"otherwise the browser will not save the cookie, fix or remove it"
+msgstr ""
+"如果你是管理員，請檢查 SESSION_COOKIE_DOMAIN 配置是否錯誤：訪問網域必須是它或它的子網域，否則瀏覽器不會保存 "
+"Cookie，請修正或刪除該配置"
+
+#: authentication/templates/authentication/login.html:321
+msgid "not set"
+msgstr "未配置"
+
+#: authentication/templates/authentication/login.html:322
+msgid ""
+"Please make sure cookies are enabled in your browser, clear the site cookies "
+"and try again"
+msgstr "請確認瀏覽器已啟用 Cookie，並清除本站 Cookie 後重試"
+
 #: authentication/templates/authentication/login.html:423
 msgid "More login options"
 msgstr "其他方式登錄"

--- a/apps/jumpserver/views/other.py
+++ b/apps/jumpserver/views/other.py
@@ -105,7 +105,8 @@ class ResourceDownload(TemplateView):
 
 def csrf_failure(request, reason=""):
     from django.shortcuts import reverse
-    login_url = reverse('authentication:login') + '?csrf_failure=1&admin=1'
+    reason_type = 'cookie' if reason.startswith('CSRF') else 'origin'
+    login_url = reverse('authentication:login') + f'?csrf_failure=1&admin=1&csrf_reason={reason_type}'
     return redirect(login_url)
 
 


### PR DESCRIPTION
#### What this PR does / why we need it?

当配置了 `SESSION_COOKIE_DOMAIN` 但访问 JumpServer 用的域名不是它或它的子域时（比如用 IP 访问、或该配置写错），浏览器会按 RFC 6265 拒收 CSRF Cookie，登录 POST 全部被 Django 以 "CSRF cookie not set" 拒绝。

而 `csrf_failure` 忽略了 Django 传入的失败原因 `reason`，所有 CSRF 失败一律重定向到登录页并提示"请配置DOMAINS=xxx"。在上述场景里这个提示是误导：DOMAINS 本身配置正确（Origin 校验其实是通过的），改 DOMAINS 永远解决不了，管理员会一直卡在反复修改 DOMAINS 的死循环里。

复现：配置 `SESSION_COOKIE_DOMAIN: example.com`，用 IP 或 `*.example.com`以外的域名打开登录页并提交表单，无论DOMAINS 怎么配，页面始终提示配置 DOMAINS。

#### Summary of your change

- `csrf_failure` ：按失败原因分类。Origin/Referer 校验失败（reason 以"Origin/Referer checking failed" 开头）保持原有 DOMAINS 提示；cookie/token 类失败（reason 以 "CSRF" 开头）带 `csrf_reason=cookie` 跳转。未知或空 reason 回退到原有行为。
- 登录页：cookie 类失败显示专门的提示，引导管理员检查 SESSION_COOKIE_DOMAIN 配置是否错误（访问域名必须是它或它的子域），展示当前配置值（未配置则显示"未配置"），并提示检查浏览器 Cookie 开关、清除本站 Cookie 后重试。Origin 类失败的页面表现与之前完全一致。
- i18n：9 种语言的 `apps/i18n/core/*` 补充了 4 条新文案翻译。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.