### PR TITLE
fix: publish applet to all hosts on create

### DIFF
--- a/apps/terminal/signal_handlers/applet.py
+++ b/apps/terminal/signal_handlers/applet.py
@@ -78,6 +78,8 @@ def on_applet_host_delete(sender, instance, **kwargs):
 def on_applet_create(sender, instance, created=False, **kwargs):
     if not created:
         return
+    hosts = AppletHost.objects.all()
+    instance.hosts.set(hosts)
     applet_host_change_pub_sub.publish(True)
 
 


### PR DESCRIPTION
#### What this PR does / why we need it?
上传远程应用包后，远程应用列表中可见，但发布机的应用列表中不会显示该远程应用
#### Summary of your change
参照原代码恢复 `on_applet_create` 中被误删的两行，新建 applet 时自动发布到所有发布机，与 v4.10.18 及之前版本行为一致
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.