### PR TITLE
fix: prevent CAS login loop for disabled users

### DIFF
--- a/apps/authentication/backends/cas/views.py
+++ b/apps/authentication/backends/cas/views.py
@@ -1,6 +1,4 @@
-from django.contrib.auth import logout as auth_logout
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django_cas_ng.views import LoginView
@@ -13,16 +11,17 @@ __all__ = ['LoginView']
 class CASLoginView(LoginView, FlashMessageMixin):
     def get(self, request):
         try:
-            resp = super().get(request)
-        except PermissionDenied:
-            resp = HttpResponseRedirect('/')
-        error_message = getattr(request, 'error_message', '')
-        if error_message:
-            auth_logout(request)
-            redirect_url = reverse('authentication:login') + '?admin=1'
-            response = self.get_failed_response(
-                redirect_url, title=_('CAS Error'), msg=error_message
+            response = super().get(request)
+        except PermissionDenied as exc:
+            error_message = (
+                getattr(request, 'error_message', '') or str(exc)
             )
-            return response
         else:
-            return resp
+            error_message = getattr(request, 'error_message', '')
+            if not error_message:
+                return response
+
+        redirect_url = reverse('authentication:login') + '?admin=1'
+        return self.get_failed_response(
+            redirect_url, title=_('CAS Error'), msg=error_message
+        )

--- a/apps/authentication/tests/test_cas.py
+++ b/apps/authentication/tests/test_cas.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.backends.signed_cookies import SessionStore
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.urls import reverse
+
+from authentication.backends.cas.views import CASLoginView, LoginView
+from common.utils import FlashMessageUtil
+
+
+@override_settings(
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        }
+    },
+    CAS_RETRY_LOGIN=False,
+    SESSION_ENGINE='django.contrib.sessions.backends.signed_cookies',
+)
+class CASLoginViewTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_failed_authentication_redirects_to_direct_login(self):
+        request = self.factory.get(
+            '/api/v1/authentication/cas/login/', {'ticket': 'invalid'}
+        )
+        request.user = AnonymousUser()
+        request.session = SessionStore()
+
+        with patch('django_cas_ng.views.get_cas_client'), patch(
+            'django_cas_ng.views.authenticate', return_value=None
+        ):
+            response = CASLoginView.as_view()(request)
+
+        location = urlsplit(response.url)
+        self.assertEqual(location.path, reverse('common:flash-message'))
+
+        message_code = parse_qs(location.query)['code'][0]
+        message_data = FlashMessageUtil.get_message_by_code(message_code)
+        self.assertEqual(
+            message_data['redirect_url'],
+            reverse('authentication:login') + '?admin=1',
+        )
+        self.assertEqual(str(message_data['error']), 'Login failed.')
+
+    def test_successful_response_is_unchanged(self):
+        request = self.factory.get('/api/v1/authentication/cas/login/')
+        expected_response = HttpResponseRedirect('/target/')
+
+        with patch.object(LoginView, 'get', return_value=expected_response):
+            response = CASLoginView.as_view()(request)
+
+        self.assertIs(response, expected_response)


### PR DESCRIPTION
#### What this PR does / why we need it?

https://github.com/jumpserver/jumpserver/pull/16657 did not fully fix the CAS redirect loop.

A disabled user is converted to `None` inside the CAS backend, so `request.error_message` remains empty and `django-cas-ng` raises `PermissionDenied`. The previous fix therefore still redirects to `/` and may restart CAS login.

#### Summary of your change

Handle `PermissionDenied` raised by `django-cas-ng` when a disabled local user is rejected, then show the error and redirect to the direct login page to prevent the CAS login loop. Add regression coverage for this path.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
